### PR TITLE
docs: replace all DecisionPrompt references with OptionList

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Responsive, accessible, typed, copy-pasteable. Built on Radix, shadcn/ui, and Ta
 ## Components
 
 - Data Table — Sortable columns, row actions, loading/empty states, mobile accordion layout
-- Decision Prompt — Inline decisions with two-stage confirms, receipt state, async-ready
+- Option List — Single/multi-select choices with configurable footer actions
 - Social Post — X/Instagram/LinkedIn renderers; media + link previews
 - Media Card — Image/video/audio/link cards; OG previews; alt-text validation
 

--- a/app/docs/design-guidelines/content-v2.mdx
+++ b/app/docs/design-guidelines/content-v2.mdx
@@ -69,26 +69,28 @@ Tool UI is the conversation-native layer between your UI primitives (Radix/shadc
 
 These examples are here to ground the guidelines in something concrete. Full docs live on each component page.
 
-### Decision Prompt (Decision Role)
+### Option List (Decision Role)
 
-Inline confirmation surface:
+Inline selection surface:
 
 ```tsx
-import { DecisionPrompt } from "@tool-ui/decision-prompt";
+import { OptionList } from "@tool-ui/option-list";
 
-<DecisionPrompt
-  id="approve-pr-42"
-  title="Approve this pull request?"
-  description="Merges feature branch into main."
-  actions={[
+<OptionList
+  options={[
     { id: "approve", label: "Approve" },
     { id: "reject", label: "Reject" },
+  ]}
+  selectionMode="single"
+  footerActions={[
+    { id: "cancel", label: "Cancel", variant: "ghost" },
+    { id: "confirm", label: "Confirm", variant: "default" },
   ]}
 />
 ```
 
-- **Intent:** "Approve or reject this pull request"  
-- **Role:** decision  
+- **Intent:** "Select an option from this list"
+- **Role:** decision
 - **Lifecycle:** invocation → interactive → receipt
 
 ### Media Card (Information Role)
@@ -187,9 +189,9 @@ Every Tool UI has a primary role defining why it exists.
 - Default to glanceable with progressive detail
 - Use visual encoding (badges, colors) to reduce load
 
-### Decision  
-**Purpose:** Capture user choice  
-**Examples:** DecisionPrompt, SingleChoice, MultiSelect  
+### Decision
+**Purpose:** Capture user choice
+**Examples:** OptionList, SingleChoice, MultiSelect
 **Patterns:**
 - One visually dominant primary action
 - Two-step confirmation for destructive actions

--- a/app/docs/overview/content.mdx
+++ b/app/docs/overview/content.mdx
@@ -156,4 +156,4 @@ Every Tool UI surface is addressable and reconstructable. Here's the common sche
 
 - **[Quick Start](/docs/quick-start)**: Wire your first Tool UI
 - **[UI Guidelines](/docs/design-guidelines)**: Patterns, roles, lifecycle, receipts
-- **[Components](/docs/data-table)**: Explore Data Table, Media Card, Decision Prompt, Social Post
+- **[Components](/docs/data-table)**: Explore Data Table, Media Card, Option List, Social Post

--- a/app/docs/quick-start/content.mdx
+++ b/app/docs/quick-start/content.mdx
@@ -163,6 +163,6 @@ assistant-ui supports multiple runtimes: AI SDK, LangGraph, LangServe, Mastra, o
 
 ## Next Steps
 
-- [**Explore Components**](/docs/data-table): Data Table, Media Card, Decision Prompt, Social Post
+- [**Explore Components**](/docs/data-table): Data Table, Media Card, Option List, Social Post
 - [**UI Guidelines**](/docs/design-guidelines): Learn the interaction patterns
 - [**Examples**](https://github.com/assistant-ui/assistant-ui/tree/main/examples): Full implementations


### PR DESCRIPTION
## Summary

- Update README.md component list
- Update design-guidelines example code and role examples  
- Update quick-start and overview component lists

All references to "Decision Prompt" / "DecisionPrompt" have been replaced with "Option List" / "OptionList".

🤖 Generated with [Claude Code](https://claude.com/claude-code)