### PR TITLE
feat: expand component presets with computing history examples

### DIFF
--- a/app/docs/_components/preset-selector.tsx
+++ b/app/docs/_components/preset-selector.tsx
@@ -29,14 +29,29 @@ const dataTablePresetNames: PresetName[] = [
   "tasks",
   "resources",
   "actions",
+  "hardware",
+  "metrics",
+  "ledger",
+  "milestones",
+  "archives",
+  "inventory",
+  "largeDataset",
 ];
 
 const mediaCardPresetNames: MediaCardPresetName[] = [
-  "link",
   "image",
   "video",
   "audio",
+  "link",
   "actions",
+  "portrait",
+  "square",
+  "podcast",
+  "product",
+  "document",
+  "screenshot",
+  "gallery",
+  "edgeCases",
 ];
 
 const optionListPresetNames: OptionListPresetName[] = [
@@ -45,6 +60,13 @@ const optionListPresetNames: OptionListPresetName[] = [
   "notifications",
   "receipt",
   "actions",
+  "approval",
+  "priority",
+  "wizard",
+  "destructive",
+  "settings",
+  "ranking",
+  "edgeCases",
 ];
 
 export function PresetSelector({

--- a/lib/presets/data-table.ts
+++ b/lib/presets/data-table.ts
@@ -376,13 +376,682 @@ const sampleActions: DataTableConfig = {
   ],
 };
 
-export type PresetName = "stocks" | "tasks" | "resources" | "actions";
+// ============================================================
+// HARDWARE CATALOG (E-commerce pattern)
+// Demonstrates: currency, number (inventory), badge, array, link
+// ============================================================
+const hardwareColumns: Column<GenericRow>[] = [
+  { key: "model", label: "Model", priority: "primary" },
+  { key: "manufacturer", label: "Manufacturer", priority: "primary" },
+  {
+    key: "price",
+    label: "Price",
+    align: "right",
+    priority: "primary",
+    format: { kind: "currency", currency: "USD", decimals: 2 },
+  },
+  {
+    key: "stock",
+    label: "Stock",
+    align: "right",
+    priority: "secondary",
+    format: { kind: "number", decimals: 0 },
+  },
+  {
+    key: "category",
+    label: "Category",
+    priority: "secondary",
+    format: {
+      kind: "badge",
+      colorMap: {
+        processor: "info",
+        memory: "success",
+        storage: "warning",
+        peripheral: "neutral",
+      },
+    },
+  },
+  {
+    key: "features",
+    label: "Features",
+    priority: "tertiary",
+    format: { kind: "array", maxVisible: 2 },
+  },
+  {
+    key: "datasheet",
+    label: "Specs",
+    priority: "tertiary",
+    format: { kind: "link", external: true },
+  },
+];
+
+const hardwareData: GenericRow[] = [
+  {
+    model: "Intel 4004",
+    manufacturer: "Intel",
+    price: 450.0,
+    stock: 12,
+    category: "processor",
+    features: ["4-bit", "740kHz", "2300 transistors"],
+    datasheet: "https://intel.com/4004",
+  },
+  {
+    model: "MOS 6502",
+    manufacturer: "MOS Technology",
+    price: 25.0,
+    stock: 847,
+    category: "processor",
+    features: ["8-bit", "1MHz", "Apple II"],
+    datasheet: "https://mos.com/6502",
+  },
+  {
+    model: "Magnetic Core Array",
+    manufacturer: "IBM",
+    price: 1200.0,
+    stock: 3,
+    category: "memory",
+    features: ["4KB", "non-volatile", "hand-woven"],
+    datasheet: "https://ibm.com/core",
+  },
+  {
+    model: "CDC 6600 Disk Pack",
+    manufacturer: "Control Data",
+    price: 3500.0,
+    stock: 0,
+    category: "storage",
+    features: ["100MB", "removable", "RAID-0"],
+    datasheet: "https://cdc.com/disk",
+  },
+  {
+    model: "Teletype Model 33",
+    manufacturer: "Teletype Corp",
+    price: 750.0,
+    stock: 24,
+    category: "peripheral",
+    features: ["110 baud", "ASCII", "paper tape"],
+    datasheet: "https://teletype.com/33",
+  },
+];
+
+const sampleHardware: DataTableConfig = {
+  surfaceId: "data-table-preview-hardware",
+  columns: hardwareColumns,
+  data: hardwareData,
+  rowIdKey: "model",
+};
+
+// ============================================================
+// SYSTEM METRICS (Analytics pattern)
+// Demonstrates: number (compact), percent, delta, date (relative)
+// ============================================================
+const metricsColumns: Column<GenericRow>[] = [
+  { key: "system", label: "System", priority: "primary" },
+  {
+    key: "uptime",
+    label: "Uptime",
+    align: "right",
+    priority: "primary",
+    format: { kind: "percent", decimals: 1, basis: "unit" },
+  },
+  {
+    key: "jobs",
+    label: "Jobs/Day",
+    align: "right",
+    priority: "primary",
+    format: { kind: "number", compact: true },
+  },
+  {
+    key: "jobsDelta",
+    label: "vs Last Week",
+    align: "right",
+    priority: "secondary",
+    format: { kind: "delta", decimals: 1, upIsPositive: true, showSign: true },
+  },
+  {
+    key: "errorRate",
+    label: "Errors",
+    align: "right",
+    priority: "secondary",
+    format: { kind: "percent", decimals: 2, basis: "unit" },
+  },
+  {
+    key: "lastReboot",
+    label: "Last Reboot",
+    priority: "tertiary",
+    format: { kind: "date", dateFormat: "relative" },
+  },
+];
+
+const metricsData: GenericRow[] = [
+  {
+    system: "ENIAC",
+    uptime: 94.2,
+    jobs: 156000,
+    jobsDelta: 12.5,
+    errorRate: 2.3,
+    lastReboot: "2025-11-01T08:00:00.000Z",
+  },
+  {
+    system: "UNIVAC I",
+    uptime: 99.1,
+    jobs: 423000,
+    jobsDelta: -3.2,
+    errorRate: 0.8,
+    lastReboot: "2025-10-15T14:30:00.000Z",
+  },
+  {
+    system: "IBM 701",
+    uptime: 87.6,
+    jobs: 89000,
+    jobsDelta: 45.0,
+    errorRate: 5.1,
+    lastReboot: "2025-11-20T22:15:00.000Z",
+  },
+  {
+    system: "SAGE",
+    uptime: 99.9,
+    jobs: 2100000,
+    jobsDelta: 0.3,
+    errorRate: 0.01,
+    lastReboot: "2025-06-01T00:00:00.000Z",
+  },
+  {
+    system: "PDP-1",
+    uptime: 78.4,
+    jobs: 34000,
+    jobsDelta: -15.7,
+    errorRate: 8.2,
+    lastReboot: "2025-11-25T16:45:00.000Z",
+  },
+];
+
+const sampleMetrics: DataTableConfig = {
+  surfaceId: "data-table-preview-metrics",
+  columns: metricsColumns,
+  data: metricsData,
+  rowIdKey: "system",
+  defaultSort: { by: "uptime", direction: "desc" },
+};
+
+// ============================================================
+// PROJECT LEDGER (Financial pattern)
+// Demonstrates: currency, status, date, boolean
+// ============================================================
+const ledgerColumns: Column<GenericRow>[] = [
+  { key: "project", label: "Project", priority: "primary" },
+  {
+    key: "budget",
+    label: "Budget",
+    align: "right",
+    priority: "primary",
+    format: { kind: "currency", currency: "USD", decimals: 0 },
+  },
+  {
+    key: "spent",
+    label: "Spent",
+    align: "right",
+    priority: "primary",
+    format: { kind: "currency", currency: "USD", decimals: 0 },
+  },
+  {
+    key: "status",
+    label: "Status",
+    priority: "secondary",
+    format: {
+      kind: "status",
+      statusMap: {
+        on_track: { tone: "success", label: "On Track" },
+        at_risk: { tone: "warning", label: "At Risk" },
+        over_budget: { tone: "danger", label: "Over Budget" },
+        completed: { tone: "info", label: "Completed" },
+      },
+    },
+  },
+  {
+    key: "fundedDate",
+    label: "Funded",
+    priority: "secondary",
+    format: { kind: "date", dateFormat: "short" },
+  },
+  {
+    key: "classified",
+    label: "Classified",
+    priority: "tertiary",
+    format: { kind: "boolean", labels: { true: "Yes", false: "No" } },
+  },
+];
+
+const ledgerData: GenericRow[] = [
+  {
+    project: "ARPANET Phase I",
+    budget: 1500000,
+    spent: 1420000,
+    status: "completed",
+    fundedDate: "1969-01-01",
+    classified: false,
+  },
+  {
+    project: "Alto Development",
+    budget: 2800000,
+    spent: 3100000,
+    status: "over_budget",
+    fundedDate: "1972-03-15",
+    classified: false,
+  },
+  {
+    project: "Multics Security",
+    budget: 850000,
+    spent: 420000,
+    status: "on_track",
+    fundedDate: "1970-06-01",
+    classified: true,
+  },
+  {
+    project: "CP/M Licensing",
+    budget: 50000,
+    spent: 48500,
+    status: "at_risk",
+    fundedDate: "1974-11-20",
+    classified: false,
+  },
+  {
+    project: "Ethernet Protocol",
+    budget: 1200000,
+    spent: 890000,
+    status: "on_track",
+    fundedDate: "1973-05-22",
+    classified: false,
+  },
+];
+
+const sampleLedger: DataTableConfig = {
+  surfaceId: "data-table-preview-ledger",
+  columns: ledgerColumns,
+  data: ledgerData,
+  rowIdKey: "project",
+};
+
+// ============================================================
+// COMPUTING MILESTONES (Timeline pattern)
+// Demonstrates: date (long), status (multi-level), boolean, link
+// ============================================================
+const milestonesColumns: Column<GenericRow>[] = [
+  { key: "event", label: "Milestone", priority: "primary" },
+  {
+    key: "date",
+    label: "Date",
+    priority: "primary",
+    format: { kind: "date", dateFormat: "long" },
+  },
+  {
+    key: "significance",
+    label: "Impact",
+    priority: "primary",
+    format: {
+      kind: "status",
+      statusMap: {
+        foundational: { tone: "danger", label: "Foundational" },
+        major: { tone: "warning", label: "Major" },
+        notable: { tone: "info", label: "Notable" },
+        incremental: { tone: "neutral", label: "Incremental" },
+      },
+    },
+  },
+  {
+    key: "documented",
+    label: "Documented",
+    priority: "secondary",
+    format: { kind: "boolean" },
+  },
+  {
+    key: "reference",
+    label: "Source",
+    priority: "tertiary",
+    format: { kind: "link", external: true },
+  },
+];
+
+const milestonesData: GenericRow[] = [
+  {
+    event: "First stored program executed (Manchester Baby)",
+    date: "1948-06-21",
+    significance: "foundational",
+    documented: true,
+    reference: "https://computerhistory.org/baby",
+  },
+  {
+    event: "FORTRAN compiler released",
+    date: "1957-04-15",
+    significance: "foundational",
+    documented: true,
+    reference: "https://ibm.com/fortran",
+  },
+  {
+    event: "First email sent on ARPANET",
+    date: "1971-10-29",
+    significance: "major",
+    documented: true,
+    reference: "https://arpanet.org/email",
+  },
+  {
+    event: "Xerox Alto demonstration",
+    date: "1973-03-01",
+    significance: "major",
+    documented: false,
+    reference: "https://parc.com/alto",
+  },
+  {
+    event: "VisiCalc released for Apple II",
+    date: "1979-10-17",
+    significance: "major",
+    documented: true,
+    reference: "https://visicalc.com",
+  },
+];
+
+const sampleMilestones: DataTableConfig = {
+  surfaceId: "data-table-preview-milestones",
+  columns: milestonesColumns,
+  data: milestonesData,
+  rowIdKey: "event",
+  defaultSort: { by: "date", direction: "asc" },
+};
+
+// ============================================================
+// DIGITAL ARCHIVES (File browser pattern)
+// Demonstrates: number (file size), date, badge, link, array
+// ============================================================
+const archivesColumns: Column<GenericRow>[] = [
+  { key: "filename", label: "File", priority: "primary" },
+  {
+    key: "sizeBytes",
+    label: "Size",
+    abbr: "Size",
+    align: "right",
+    priority: "primary",
+    format: { kind: "number", compact: true, unit: "B" },
+  },
+  {
+    key: "type",
+    label: "Type",
+    priority: "primary",
+    format: {
+      kind: "badge",
+      colorMap: {
+        source: "info",
+        binary: "warning",
+        document: "success",
+        image: "neutral",
+      },
+    },
+  },
+  {
+    key: "modified",
+    label: "Modified",
+    priority: "secondary",
+    format: { kind: "date", dateFormat: "relative" },
+  },
+  {
+    key: "permissions",
+    label: "Access",
+    priority: "secondary",
+    format: { kind: "array", maxVisible: 3 },
+  },
+  {
+    key: "path",
+    label: "Location",
+    priority: "tertiary",
+    format: { kind: "link" },
+  },
+];
+
+const archivesData: GenericRow[] = [
+  {
+    filename: "hello.c",
+    sizeBytes: 1024,
+    type: "source",
+    modified: "2025-11-28T10:30:00.000Z",
+    permissions: ["read", "write", "execute"],
+    path: "/usr/src/hello.c",
+  },
+  {
+    filename: "kernel.bin",
+    sizeBytes: 524288,
+    type: "binary",
+    modified: "2025-11-15T08:00:00.000Z",
+    permissions: ["read", "execute"],
+    path: "/boot/kernel.bin",
+  },
+  {
+    filename: "README.txt",
+    sizeBytes: 2048,
+    type: "document",
+    modified: "2025-11-20T14:45:00.000Z",
+    permissions: ["read"],
+    path: "/docs/README.txt",
+  },
+  {
+    filename: "logo.xbm",
+    sizeBytes: 4096,
+    type: "image",
+    modified: "2025-10-01T09:00:00.000Z",
+    permissions: ["read", "write"],
+    path: "/assets/logo.xbm",
+  },
+  {
+    filename: "libc.a",
+    sizeBytes: 2097152,
+    type: "binary",
+    modified: "2025-11-01T00:00:00.000Z",
+    permissions: ["read"],
+    path: "/lib/libc.a",
+  },
+];
+
+const sampleArchives: DataTableConfig = {
+  surfaceId: "data-table-preview-archives",
+  columns: archivesColumns,
+  data: archivesData,
+  rowIdKey: "filename",
+};
+
+// ============================================================
+// PARTS INVENTORY (Inventory management pattern)
+// Demonstrates: number (stock), status (levels), currency, delta
+// ============================================================
+const inventoryColumns: Column<GenericRow>[] = [
+  { key: "partNumber", label: "Part #", priority: "primary" },
+  { key: "description", label: "Description", priority: "primary", truncate: true },
+  {
+    key: "quantity",
+    label: "Qty",
+    align: "right",
+    priority: "primary",
+    format: { kind: "number", decimals: 0 },
+  },
+  {
+    key: "stockLevel",
+    label: "Status",
+    priority: "primary",
+    format: {
+      kind: "status",
+      statusMap: {
+        adequate: { tone: "success", label: "In Stock" },
+        low: { tone: "warning", label: "Low Stock" },
+        critical: { tone: "danger", label: "Critical" },
+        out: { tone: "danger", label: "Out of Stock" },
+      },
+    },
+  },
+  {
+    key: "unitCost",
+    label: "Unit Cost",
+    align: "right",
+    priority: "secondary",
+    format: { kind: "currency", currency: "USD", decimals: 2 },
+  },
+  {
+    key: "weeklyChange",
+    label: "Weekly",
+    align: "right",
+    priority: "secondary",
+    format: { kind: "delta", decimals: 0, upIsPositive: false, showSign: true },
+  },
+];
+
+const inventoryData: GenericRow[] = [
+  {
+    partNumber: "VAC-12AX7",
+    description: "Vacuum tube, dual triode, audio preamp",
+    quantity: 2400,
+    stockLevel: "adequate",
+    unitCost: 12.5,
+    weeklyChange: -120,
+  },
+  {
+    partNumber: "RES-1K-5W",
+    description: "Carbon resistor, 1K ohm, 5 watt",
+    quantity: 150,
+    stockLevel: "low",
+    unitCost: 0.15,
+    weeklyChange: -340,
+  },
+  {
+    partNumber: "CAP-10UF",
+    description: "Electrolytic capacitor, 10uF, 50V",
+    quantity: 0,
+    stockLevel: "out",
+    unitCost: 0.45,
+    weeklyChange: -85,
+  },
+  {
+    partNumber: "TRANS-PWR",
+    description: "Power transformer, 120V to 6.3V/250V",
+    quantity: 8,
+    stockLevel: "critical",
+    unitCost: 45.0,
+    weeklyChange: -4,
+  },
+  {
+    partNumber: "WIRE-22AWG",
+    description: "Hookup wire, 22 AWG, solid core (per ft)",
+    quantity: 50000,
+    stockLevel: "adequate",
+    unitCost: 0.02,
+    weeklyChange: 10000,
+  },
+];
+
+const sampleInventory: DataTableConfig = {
+  surfaceId: "data-table-preview-inventory",
+  columns: inventoryColumns,
+  data: inventoryData,
+  rowIdKey: "partNumber",
+  defaultSort: { by: "quantity", direction: "asc" },
+};
+
+// ============================================================
+// LARGE DATASET (Performance testing)
+// Demonstrates: Scrolling behavior with 100+ rows
+// ============================================================
+function generateLargeDataset(): GenericRow[] {
+  const systems = [
+    "ENIAC", "UNIVAC", "IBM 701", "SAGE", "PDP-1", "IBM 7090",
+    "CDC 6600", "PDP-8", "IBM System/360", "PDP-11", "Alto",
+    "Apple II", "VAX-11", "IBM PC", "Macintosh", "NeXT"
+  ];
+  const statuses = ["online", "maintenance", "offline", "degraded"];
+  const rows: GenericRow[] = [];
+
+  for (let i = 0; i < 120; i++) {
+    const system = systems[i % systems.length];
+    const instance = Math.floor(i / systems.length) + 1;
+    rows.push({
+      id: `SYS-${String(i + 1).padStart(4, "0")}`,
+      name: `${system} #${instance}`,
+      status: statuses[i % statuses.length],
+      cpu: Math.round(Math.random() * 100),
+      memory: Math.round(Math.random() * 100),
+      lastSeen: new Date(Date.now() - Math.random() * 86400000 * 30).toISOString(),
+    });
+  }
+  return rows;
+}
+
+const largeDatasetColumns: Column<GenericRow>[] = [
+  { key: "id", label: "ID", priority: "primary" },
+  { key: "name", label: "System", priority: "primary" },
+  {
+    key: "status",
+    label: "Status",
+    priority: "primary",
+    format: {
+      kind: "status",
+      statusMap: {
+        online: { tone: "success" },
+        maintenance: { tone: "warning" },
+        offline: { tone: "danger" },
+        degraded: { tone: "info" },
+      },
+    },
+  },
+  {
+    key: "cpu",
+    label: "CPU %",
+    align: "right",
+    priority: "secondary",
+    format: { kind: "percent", decimals: 0, basis: "unit" },
+  },
+  {
+    key: "memory",
+    label: "Mem %",
+    align: "right",
+    priority: "secondary",
+    format: { kind: "percent", decimals: 0, basis: "unit" },
+  },
+  {
+    key: "lastSeen",
+    label: "Last Seen",
+    priority: "tertiary",
+    format: { kind: "date", dateFormat: "relative" },
+  },
+];
+
+const sampleLargeDataset: DataTableConfig = {
+  surfaceId: "data-table-preview-large",
+  columns: largeDatasetColumns,
+  data: generateLargeDataset(),
+  rowIdKey: "id",
+  maxHeight: "400px",
+};
+
+export type PresetName =
+  | "stocks"
+  | "tasks"
+  | "resources"
+  | "actions"
+  // New presets
+  | "hardware"      // E-commerce style: vintage hardware catalog
+  | "metrics"       // Analytics: system performance metrics
+  | "ledger"        // Financial: computing project expenses
+  | "milestones"    // Timeline: computing history milestones
+  | "archives"      // File browser: digital archive files
+  | "inventory"     // Inventory: parts and components
+  | "largeDataset"; // Performance: 100+ rows
 
 export const presets: Record<PresetName, DataTableConfig> = {
   stocks: sampleStocks,
   tasks: sampleTasks,
   resources: sampleResources,
   actions: sampleActions,
+  // New presets
+  hardware: sampleHardware,
+  metrics: sampleMetrics,
+  ledger: sampleLedger,
+  milestones: sampleMilestones,
+  archives: sampleArchives,
+  inventory: sampleInventory,
+  largeDataset: sampleLargeDataset,
 };
 
 export const presetDescriptions: Record<PresetName, string> = {
@@ -390,4 +1059,12 @@ export const presetDescriptions: Record<PresetName, string> = {
   tasks: "Status pills, boolean badges, and date formatting",
   resources: "Links, tag arrays, badges, and relative dates",
   actions: "Support ticket queue with footer actions",
+  // New descriptions
+  hardware: "Vintage hardware catalog with inventory and categories",
+  metrics: "System performance with uptime, throughput, and trends",
+  ledger: "Project finances with budget tracking and status",
+  milestones: "Historical timeline with significance levels",
+  archives: "File browser with sizes, types, and permissions",
+  inventory: "Parts management with stock levels and reorder alerts",
+  largeDataset: "100+ rows for scroll and performance testing",
 };

--- a/lib/presets/media-card.ts
+++ b/lib/presets/media-card.ts
@@ -6,7 +6,21 @@ export interface MediaCardConfig {
   footerActions?: SerializableAction[];
 }
 
-export type MediaCardPresetName = "image" | "video" | "audio" | "link" | "actions";
+export type MediaCardPresetName =
+  | "image"
+  | "video"
+  | "audio"
+  | "link"
+  | "actions"
+  // New presets
+  | "portrait"    // 9:16 ratio image
+  | "square"      // 1:1 ratio image
+  | "podcast"     // Long-form audio
+  | "product"     // E-commerce style
+  | "document"    // PDF/doc link
+  | "screenshot"  // Auto ratio, minimal
+  | "gallery"     // Carousel-ready
+  | "edgeCases";  // Missing data, errors
 
 const imagePreset: MediaCardConfig = {
   card: {
@@ -132,12 +146,196 @@ const actionsPreset: MediaCardConfig = {
   ],
 };
 
+// ============================================================
+// PORTRAIT IMAGE (9:16 Stories format)
+// ============================================================
+const portraitPreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-portrait",
+    assetId: "media-card-portrait",
+    kind: "image",
+    src: "https://images.unsplash.com/photo-1729944950511-e9c71556cfd4?w=450&h=800&auto=format&fit=crop",
+    alt: "Vintage CRT monitor with green text display",
+    title: "The terminal aesthetic",
+    description: "Before GUIs, this green glow was the face of computing.",
+    ratio: "9:16",
+    domain: "unsplash.com",
+    createdAtISO: "2025-11-20T10:00:00.000Z",
+    source: {
+      label: "RetroTech Archive",
+      iconUrl: "https://api.dicebear.com/7.x/shapes/svg?seed=retro",
+    },
+  },
+};
+
+// ============================================================
+// SQUARE IMAGE (1:1 social media format)
+// ============================================================
+const squarePreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-square",
+    assetId: "media-card-square",
+    kind: "image",
+    src: "https://images.unsplash.com/photo-1518770660439-4636190af475?w=600&h=600&auto=format&fit=crop",
+    alt: "Close-up of a vintage circuit board",
+    title: "Silicon dreams",
+    description: "A macro view of the circuits that changed everything.",
+    ratio: "1:1",
+    fit: "cover",
+    domain: "unsplash.com",
+    createdAtISO: "2025-11-18T14:30:00.000Z",
+  },
+};
+
+// ============================================================
+// PODCAST EPISODE (Long-form audio)
+// ============================================================
+const podcastPreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-podcast",
+    assetId: "media-card-podcast",
+    kind: "audio",
+    src: "https://samplelib.com/lib/preview/mp3/sample-6s.mp3",
+    title: "Oral History: The ARPANET Years",
+    description: "Vint Cerf recounts the early days of packet switching, the first successful message transmission, and the culture of collaboration that built the internet.",
+    thumb: "https://images.unsplash.com/photo-1504548840739-580b10ae7715?w=400&auto=format&fit=crop",
+    durationMs: 4823000, // ~80 minutes
+    fileSizeBytes: 76800000, // ~76MB
+    domain: "computerhistory.org",
+    createdAtISO: "2025-11-10T08:00:00.000Z",
+    source: {
+      label: "Computing Pioneers Podcast",
+      iconUrl: "https://api.dicebear.com/7.x/shapes/svg?seed=podcast",
+      url: "https://computerhistory.org/podcast",
+    },
+  },
+};
+
+// ============================================================
+// PRODUCT IMAGE (E-commerce style)
+// ============================================================
+const productPreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-product",
+    assetId: "media-card-product",
+    kind: "image",
+    src: "https://images.unsplash.com/photo-1562408590-e32931084e23?w=600&auto=format&fit=crop",
+    alt: "Vintage mechanical keyboard with beige keycaps",
+    title: "Model M Keyboard",
+    description: "The legendary IBM buckling spring keyboard. Built to last decades.",
+    ratio: "4:3",
+    fit: "contain",
+    domain: "vintagecomputing.shop",
+    createdAtISO: "2025-11-25T12:00:00.000Z",
+    source: {
+      label: "Vintage Computing Shop",
+      iconUrl: "https://api.dicebear.com/7.x/shapes/svg?seed=shop",
+      url: "https://vintagecomputing.shop",
+    },
+  },
+  footerActions: [
+    { id: "add-to-cart", label: "Add to Cart", variant: "default" },
+    { id: "wishlist", label: "Save", variant: "secondary" },
+  ],
+};
+
+// ============================================================
+// DOCUMENT LINK (PDF/document preview)
+// ============================================================
+const documentPreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-document",
+    assetId: "media-card-document",
+    kind: "link",
+    href: "https://example.com/turing-1936.pdf",
+    src: "https://example.com/turing-1936.pdf",
+    title: "On Computable Numbers (1936)",
+    description: "Alan Turing's foundational paper introducing the concept of a universal computing machine. PDF, 36 pages.",
+    thumb: "https://images.unsplash.com/photo-1488229297570-58520851e868?w=600&h=400&fit=crop",
+    ratio: "4:3",
+    domain: "archive.org",
+    createdAtISO: "1936-11-12T00:00:00.000Z",
+    source: {
+      label: "Internet Archive",
+      iconUrl: "https://api.dicebear.com/7.x/shapes/svg?seed=archive",
+    },
+    og: {
+      title: "On Computable Numbers, with an Application to the Entscheidungsproblem",
+      description: "Proceedings of the London Mathematical Society",
+    },
+  },
+};
+
+// ============================================================
+// SCREENSHOT (Auto ratio, minimal metadata)
+// ============================================================
+const screenshotPreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-screenshot",
+    assetId: "media-card-screenshot",
+    kind: "image",
+    src: "https://images.unsplash.com/photo-1677022725616-91e41d36db21?w=1200&auto=format&fit=crop",
+    alt: "Screenshot of early Macintosh desktop",
+    title: "macpaint-demo.png",
+    ratio: "auto",
+    createdAtISO: "2025-11-28T09:15:00.000Z",
+  },
+};
+
+// ============================================================
+// GALLERY ITEM (Carousel-ready, consistent sizing)
+// ============================================================
+const galleryPreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-gallery",
+    assetId: "media-card-gallery",
+    kind: "image",
+    src: "https://images.unsplash.com/photo-1594202304180-f25d9c992442?w=800&h=600&auto=format&fit=crop",
+    alt: "Xerox Alto workstation with mouse and keyboard",
+    title: "Xerox Alto (1973)",
+    description: "3 of 24",
+    ratio: "4:3",
+    fit: "cover",
+    createdAtISO: "2025-11-01T00:00:00.000Z",
+    source: {
+      label: "Computing History Gallery",
+    },
+  },
+};
+
+// ============================================================
+// EDGE CASES (Missing data, minimal content)
+// ============================================================
+const edgeCasesPreset: MediaCardConfig = {
+  card: {
+    surfaceId: "media-card-preview-edge",
+    assetId: "media-card-edge",
+    kind: "image",
+    src: "https://images.unsplash.com/photo-1518770660439-4636190af475?w=100&h=100&fit=crop",
+    alt: "Low resolution test image",
+    // No title
+    // No description
+    // No source
+    ratio: "1:1",
+    // Very small image to test low-res handling
+  },
+};
+
 export const mediaCardPresets: Record<MediaCardPresetName, MediaCardConfig> = {
   image: imagePreset,
   video: videoPreset,
   audio: audioPreset,
   link: linkPreset,
   actions: actionsPreset,
+  // New presets
+  portrait: portraitPreset,
+  square: squarePreset,
+  podcast: podcastPreset,
+  product: productPreset,
+  document: documentPreset,
+  screenshot: screenshotPreset,
+  gallery: galleryPreset,
+  edgeCases: edgeCasesPreset,
 };
 
 export const mediaCardPresetDescriptions: Record<MediaCardPresetName, string> =
@@ -147,4 +345,13 @@ export const mediaCardPresetDescriptions: Record<MediaCardPresetName, string> =
     audio: "Audio clip with optional poster artwork and duration metadata",
     link: "Rich link preview using OpenGraph data",
     actions: "Image with footer action buttons and confirmation",
+    // New descriptions
+    portrait: "Vertical image (9:16) for Stories/Reels format",
+    square: "Square image (1:1) for social media posts",
+    podcast: "Long-form audio with episode metadata",
+    product: "E-commerce product image with add-to-cart actions",
+    document: "PDF/document link preview",
+    screenshot: "Auto-ratio screenshot with minimal metadata",
+    gallery: "Carousel-ready image with position indicator",
+    edgeCases: "Minimal content with missing optional fields",
   };

--- a/lib/presets/option-list.ts
+++ b/lib/presets/option-list.ts
@@ -9,7 +9,15 @@ export type OptionListPresetName =
   | "travel"
   | "notifications"
   | "receipt"
-  | "actions";
+  | "actions"
+  // New presets
+  | "approval"     // All required (checklist)
+  | "priority"     // Single with impact levels
+  | "wizard"       // Back/Next navigation
+  | "destructive"  // Delete confirmation
+  | "settings"     // Multi-select preferences
+  | "ranking"      // Single with order info
+  | "edgeCases";   // Disabled, long text
 
 const exportPreset: OptionListConfig = {
   optionList: {
@@ -127,6 +135,255 @@ const actionsPreset: OptionListConfig = {
   },
 };
 
+// ============================================================
+// APPROVAL CHECKLIST (All items required)
+// ============================================================
+const approvalPreset: OptionListConfig = {
+  optionList: {
+    surfaceId: "option-list-preview-approval",
+    options: [
+      {
+        id: "code-review",
+        label: "Code Review Complete",
+        description: "All reviewers have approved",
+      },
+      {
+        id: "tests-pass",
+        label: "Tests Passing",
+        description: "CI pipeline is green",
+      },
+      {
+        id: "docs-updated",
+        label: "Documentation Updated",
+        description: "README and API docs current",
+      },
+      {
+        id: "changelog",
+        label: "Changelog Entry Added",
+        description: "Version bump noted",
+      },
+    ],
+    selectionMode: "multi",
+    minSelections: 4, // All required
+    footerActions: [
+      { id: "cancel", label: "Cancel", variant: "ghost" },
+      {
+        id: "approve",
+        label: "Approve Release",
+        confirmLabel: "Confirm Release",
+        variant: "default",
+      },
+    ],
+  },
+};
+
+// ============================================================
+// PRIORITY SELECTION (Impact levels with destructive)
+// ============================================================
+const priorityPreset: OptionListConfig = {
+  optionList: {
+    surfaceId: "option-list-preview-priority",
+    options: [
+      {
+        id: "p0",
+        label: "P0 - Critical",
+        description: "Production is down, immediate action required",
+      },
+      {
+        id: "p1",
+        label: "P1 - High",
+        description: "Major functionality impacted, fix within 24h",
+      },
+      {
+        id: "p2",
+        label: "P2 - Medium",
+        description: "Workaround available, fix within 1 week",
+      },
+      {
+        id: "p3",
+        label: "P3 - Low",
+        description: "Minor issue, fix when convenient",
+      },
+    ],
+    selectionMode: "single",
+    footerActions: [
+      { id: "cancel", label: "Cancel", variant: "ghost" },
+      { id: "set", label: "Set Priority", variant: "default" },
+    ],
+  },
+};
+
+// ============================================================
+// WIZARD NAVIGATION (Back/Next pattern)
+// ============================================================
+const wizardPreset: OptionListConfig = {
+  optionList: {
+    surfaceId: "option-list-preview-wizard",
+    options: [
+      {
+        id: "new",
+        label: "Create New Project",
+        description: "Start from scratch with our templates",
+      },
+      {
+        id: "import",
+        label: "Import Existing",
+        description: "Bring in code from GitHub, GitLab, or Bitbucket",
+      },
+      {
+        id: "clone",
+        label: "Clone Template",
+        description: "Fork one of our starter templates",
+      },
+    ],
+    selectionMode: "single",
+    footerActions: [
+      { id: "back", label: "Back", variant: "ghost" },
+      { id: "next", label: "Next Step", variant: "default" },
+    ],
+  },
+};
+
+// ============================================================
+// DESTRUCTIVE CONFIRMATION (Delete with safeguards)
+// ============================================================
+const destructivePreset: OptionListConfig = {
+  optionList: {
+    surfaceId: "option-list-preview-destructive",
+    options: [
+      {
+        id: "soft-delete",
+        label: "Move to Trash",
+        description: "Can be restored within 30 days",
+      },
+      {
+        id: "hard-delete",
+        label: "Delete Permanently",
+        description: "Cannot be undone, all data will be lost",
+      },
+      {
+        id: "archive",
+        label: "Archive Instead",
+        description: "Hide from view but keep all data",
+      },
+    ],
+    selectionMode: "single",
+    footerActions: [
+      { id: "cancel", label: "Cancel", variant: "ghost" },
+      {
+        id: "confirm",
+        label: "Delete",
+        confirmLabel: "Confirm Delete",
+        variant: "destructive",
+      },
+    ],
+  },
+};
+
+// ============================================================
+// SETTINGS PREFERENCES (Multi-select toggles)
+// ============================================================
+const settingsPreset: OptionListConfig = {
+  optionList: {
+    surfaceId: "option-list-preview-settings",
+    options: [
+      {
+        id: "dark-mode",
+        label: "Dark Mode",
+        description: "Use dark theme throughout the application",
+      },
+      {
+        id: "notifications",
+        label: "Push Notifications",
+        description: "Receive alerts on your device",
+      },
+      {
+        id: "analytics",
+        label: "Usage Analytics",
+        description: "Help us improve by sharing anonymous usage data",
+      },
+      {
+        id: "beta",
+        label: "Beta Features",
+        description: "Get early access to experimental features",
+      },
+    ],
+    selectionMode: "multi",
+    footerActions: [
+      { id: "reset", label: "Reset to Defaults", variant: "ghost" },
+      { id: "save", label: "Save Preferences", variant: "default" },
+    ],
+  },
+};
+
+// ============================================================
+// RANKING SELECTION (Ordered options)
+// ============================================================
+const rankingPreset: OptionListConfig = {
+  optionList: {
+    surfaceId: "option-list-preview-ranking",
+    options: [
+      {
+        id: "first",
+        label: "1st Choice: ENIAC",
+        description: "First general-purpose electronic computer",
+      },
+      {
+        id: "second",
+        label: "2nd Choice: UNIVAC",
+        description: "First commercial computer in the US",
+      },
+      {
+        id: "third",
+        label: "3rd Choice: IBM 701",
+        description: "IBM's first commercial scientific computer",
+      },
+    ],
+    selectionMode: "single",
+    footerActions: [
+      { id: "clear", label: "Clear", variant: "ghost" },
+      { id: "submit", label: "Submit Vote", variant: "default" },
+    ],
+  },
+};
+
+// ============================================================
+// EDGE CASES (Disabled options, long text)
+// ============================================================
+const edgeCasesPreset: OptionListConfig = {
+  optionList: {
+    surfaceId: "option-list-preview-edge-cases",
+    options: [
+      {
+        id: "enabled",
+        label: "Enabled Option",
+        description: "This option can be selected normally",
+      },
+      {
+        id: "disabled",
+        label: "Disabled Option",
+        description: "This option is disabled and cannot be selected",
+        disabled: true,
+      },
+      {
+        id: "long-text",
+        label: "Option with Very Long Label That Should Wrap or Truncate Gracefully",
+        description: "This description is also quite long to test how the component handles text overflow and wrapping in both the label and description areas of an option item.",
+      },
+      {
+        id: "no-description",
+        label: "Option Without Description",
+      },
+    ],
+    selectionMode: "multi",
+    maxSelections: 2,
+    footerActions: [
+      { id: "cancel", label: "Cancel", variant: "ghost" },
+      { id: "confirm", label: "Confirm", variant: "default" },
+    ],
+  },
+};
+
 export const optionListPresets: Record<OptionListPresetName, OptionListConfig> =
   {
     export: exportPreset,
@@ -134,6 +391,14 @@ export const optionListPresets: Record<OptionListPresetName, OptionListConfig> =
     notifications: notificationsPreset,
     receipt: receiptPreset,
     actions: actionsPreset,
+    // New presets
+    approval: approvalPreset,
+    priority: priorityPreset,
+    wizard: wizardPreset,
+    destructive: destructivePreset,
+    settings: settingsPreset,
+    ranking: rankingPreset,
+    edgeCases: edgeCasesPreset,
   };
 
 export const optionListPresetDescriptions: Record<
@@ -145,4 +410,12 @@ export const optionListPresetDescriptions: Record<
   notifications: "Multi-select with reset/confirm",
   receipt: "Confirmed selection (receipt state)",
   actions: "Footer actions with confirmation pattern",
+  // New descriptions
+  approval: "Release checklist (all items required)",
+  priority: "Bug priority levels with impact descriptions",
+  wizard: "Step navigation with back/next",
+  destructive: "Delete confirmation with safeguards",
+  settings: "User preferences toggles",
+  ranking: "Ordered choice selection",
+  edgeCases: "Disabled options, long text, missing descriptions",
 };

--- a/lib/presets/social-post.ts
+++ b/lib/presets/social-post.ts
@@ -220,7 +220,249 @@ const sampleActions: SocialPostConfig = {
   ],
 };
 
-export type SocialPostPresetName = "x" | "instagram" | "linkedin" | "actions";
+// ============================================================
+// VIDEO POST (X with video media)
+// ============================================================
+const sampleVideo: SocialPostConfig = {
+  post: {
+    surfaceId: "social-post-preview-video",
+    postId: "x-video-1",
+    platform: "x",
+    author: {
+      name: "Computer History Museum",
+      handle: "computerhistory",
+      avatarUrl: "https://api.dicebear.com/7.x/shapes/svg?seed=CHM",
+      verified: true,
+    },
+    text: "Rare footage: Watch Grace Hopper explain why we call them 'bugs' in software. This 1985 interview remains one of the best explanations of early computing challenges.",
+    entities: {
+      hashtags: ["GraceHopper", "ComputingHistory", "Debugging"],
+      mentions: [],
+    },
+    media: [
+      {
+        kind: "video",
+        url: "https://samplelib.com/lib/preview/mp4/sample-5s.mp4",
+        thumbUrl: "https://images.unsplash.com/photo-1518770660439-4636190af475?w=800&h=450&fit=crop",
+        aspectHint: "16:9",
+      },
+    ],
+    stats: {
+      likes: 12400,
+      comments: 892,
+      reposts: 3200,
+      views: 458000,
+      bookmarks: 1560,
+    },
+    createdAtISO: "2025-11-20T15:30:00.000Z",
+    actions: [
+      { id: "like", label: "Like", variant: "ghost" },
+      { id: "share", label: "Share", variant: "ghost" },
+    ],
+  },
+};
+
+// ============================================================
+// THREAD STARTER (X thread pattern)
+// ============================================================
+const sampleThread: SocialPostConfig = {
+  post: {
+    surfaceId: "social-post-preview-thread",
+    postId: "x-thread-1",
+    platform: "x",
+    author: {
+      name: "Ken Thompson",
+      handle: "ken_thompson",
+      avatarUrl: "https://api.dicebear.com/7.x/avataaars/svg?seed=Ken",
+      verified: true,
+    },
+    text: "A thread on why we made certain decisions in UNIX (1/12):\n\nWhen Dennis and I started, we had one goal: make an operating system we actually wanted to use. Everything else followed from that.",
+    entities: {
+      hashtags: ["UNIX", "OperatingSystems"],
+      mentions: ["dmr"],
+    },
+    stats: {
+      likes: 8942,
+      comments: 1247,
+      reposts: 2100,
+      views: 234000,
+    },
+    createdAtISO: "2025-11-18T10:00:00.000Z",
+    actions: [
+      { id: "like", label: "Like", variant: "ghost" },
+      { id: "bookmark", label: "Bookmark", variant: "ghost" },
+    ],
+  },
+};
+
+// ============================================================
+// REEL (Instagram vertical video)
+// ============================================================
+const sampleReel: SocialPostConfig = {
+  post: {
+    surfaceId: "social-post-preview-reel",
+    postId: "ig-reel-1",
+    platform: "instagram",
+    author: {
+      name: "RetroTech",
+      handle: "retrotech",
+      avatarUrl: "https://api.dicebear.com/7.x/shapes/svg?seed=retro",
+      verified: false,
+    },
+    text: "POV: You're debugging on an original Apple II in 1978 ✨ The green phosphor glow, the click of the keyboard, the satisfaction of finally getting it right. #retrocomputing #apple2 #nostalgia",
+    entities: {
+      hashtags: ["retrocomputing", "apple2", "nostalgia"],
+      mentions: [],
+    },
+    media: [
+      {
+        kind: "video",
+        url: "https://samplelib.com/lib/preview/mp4/sample-5s.mp4",
+        thumbUrl: "https://images.unsplash.com/photo-1677022725616-91e41d36db21?w=450&h=800&fit=crop",
+        aspectHint: "9:16",
+      },
+    ],
+    stats: {
+      likes: 45200,
+      comments: 1823,
+    },
+    createdAtISO: "2025-11-22T20:00:00.000Z",
+  },
+};
+
+// ============================================================
+// LONG-FORM (LinkedIn at character limit)
+// ============================================================
+const sampleLongForm: SocialPostConfig = {
+  post: {
+    surfaceId: "social-post-preview-longform",
+    postId: "linkedin-long-1",
+    platform: "linkedin",
+    author: {
+      name: "Margaret Hamilton",
+      handle: "margarethamilton",
+      avatarUrl: "https://api.dicebear.com/7.x/avataaars/svg?seed=Margaret",
+      verified: false,
+      subtitle: "Director of Software Engineering | Apollo Program Veteran",
+    },
+    text: `I've been thinking about what we learned during the Apollo program that still applies to software today.
+
+When we were building the guidance computer's software, we didn't have the luxury of "move fast and break things." A bug meant astronauts' lives were at risk. This forced us to develop practices that many teams still struggle with today:
+
+1. Priority-based scheduling: The computer had to handle the most critical tasks first, always. When the landing radar overloaded the system during Apollo 11's descent, our priority system saved the mission.
+
+2. Human-centered error handling: We designed for the reality that humans make mistakes. The software needed to recognize, report, and recover from errors gracefully.
+
+3. Rigorous testing with real scenarios: We tested not just individual components, but the entire integrated system under realistic conditions.
+
+4. Documentation as a first-class citizen: Every decision, every line of code was documented. Future maintainers needed to understand why, not just what.
+
+The most important lesson? Software engineering isn't just about writing code. It's about building systems that work reliably in the real world, where requirements change, humans make mistakes, and failure isn't an option.
+
+What practices from early computing do you think we've forgotten? I'd love to hear your thoughts.`,
+    entities: {
+      hashtags: ["SoftwareEngineering", "Apollo", "Leadership", "TechHistory"],
+      mentions: [],
+    },
+    stats: {
+      likes: 24500,
+    },
+    createdAtISO: "2025-11-15T09:00:00.000Z",
+    actions: [
+      { id: "like", label: "Like", variant: "ghost" },
+      { id: "comment", label: "Comment", variant: "ghost" },
+    ],
+  },
+};
+
+// ============================================================
+// MINIMAL (Edge case: minimal content)
+// ============================================================
+const sampleMinimal: SocialPostConfig = {
+  post: {
+    surfaceId: "social-post-preview-minimal",
+    postId: "x-minimal-1",
+    platform: "x",
+    author: {
+      name: "Anonymous",
+      handle: "anon",
+      avatarUrl: "https://api.dicebear.com/7.x/shapes/svg?seed=anon",
+      verified: false,
+    },
+    text: ".",
+    stats: {},
+    createdAtISO: "2025-11-01T00:00:00.000Z",
+  },
+};
+
+// ============================================================
+// MAX CONTENT (Edge case: maximum everything)
+// ============================================================
+const sampleMaxContent: SocialPostConfig = {
+  post: {
+    surfaceId: "social-post-preview-maxcontent",
+    postId: "ig-max-1",
+    platform: "instagram",
+    author: {
+      name: "Very Long Username That Tests Truncation Behavior",
+      handle: "verylonghandlethatalsoteststhetruncationbehavior",
+      avatarUrl: "https://api.dicebear.com/7.x/avataaars/svg?seed=max",
+      verified: true,
+    },
+    text: "Testing maximum content limits across all fields. This post has multiple images, many hashtags, and lots of engagement numbers to verify that the component handles large data gracefully. #test #maximum #content #limits #edge #case #computing #history #software #engineering #development",
+    entities: {
+      hashtags: ["test", "maximum", "content", "limits", "edge", "case", "computing", "history", "software", "engineering", "development"],
+      mentions: ["user1", "user2", "user3", "user4", "user5"],
+    },
+    media: [
+      {
+        kind: "image",
+        url: "https://images.unsplash.com/photo-1729944950511-e9c71556cfd4?w=800&h=800&fit=crop",
+        alt: "Test image 1",
+        aspectHint: "1:1",
+      },
+      {
+        kind: "image",
+        url: "https://images.unsplash.com/photo-1677022725616-91e41d36db21?w=800&h=800&fit=crop",
+        alt: "Test image 2",
+        aspectHint: "1:1",
+      },
+      {
+        kind: "image",
+        url: "https://images.unsplash.com/photo-1594202304180-f25d9c992442?w=800&h=800&fit=crop",
+        alt: "Test image 3",
+        aspectHint: "1:1",
+      },
+      {
+        kind: "image",
+        url: "https://images.unsplash.com/photo-1518770660439-4636190af475?w=800&h=800&fit=crop",
+        alt: "Test image 4",
+        aspectHint: "1:1",
+      },
+    ],
+    stats: {
+      likes: 9999999,
+      comments: 999999,
+      reposts: 99999,
+      views: 99999999,
+      bookmarks: 9999,
+    },
+    createdAtISO: "2025-11-25T23:59:59.000Z",
+  },
+};
+
+export type SocialPostPresetName =
+  | "x"
+  | "instagram"
+  | "linkedin"
+  | "actions"
+  // New presets
+  | "video"       // X with video content
+  | "thread"      // X thread starter
+  | "reel"        // Instagram vertical video
+  | "longForm"    // LinkedIn at character limit
+  | "minimal"     // Minimal content edge case
+  | "maxContent"; // Maximum content edge case
 
 export const socialPostPresets: Record<SocialPostPresetName, SocialPostConfig> =
   {
@@ -228,6 +470,13 @@ export const socialPostPresets: Record<SocialPostPresetName, SocialPostConfig> =
     instagram: sampleInstagram,
     linkedin: sampleLinkedIn,
     actions: sampleActions,
+    // New presets
+    video: sampleVideo,
+    thread: sampleThread,
+    reel: sampleReel,
+    longForm: sampleLongForm,
+    minimal: sampleMinimal,
+    maxContent: sampleMaxContent,
   };
 
 export const socialPostPresetDescriptions: Record<
@@ -238,4 +487,11 @@ export const socialPostPresetDescriptions: Record<
   instagram: "Instagram post with multiple images",
   linkedin: "LinkedIn post with link preview",
   actions: "Post with platform actions and footer actions",
+  // New descriptions
+  video: "X post with video media and high engagement",
+  thread: "X thread starter with continuation indicator",
+  reel: "Instagram vertical video (9:16 aspect ratio)",
+  longForm: "LinkedIn post at character limit",
+  minimal: "Edge case: minimal content (single character)",
+  maxContent: "Edge case: maximum content (long text, many images)",
 };


### PR DESCRIPTION
## What
Add 28 new presets across 4 documentation components using vintage computing themes (ENIAC, UNIVAC, Alto, etc).

## Why
The existing preset library was limited to 4-5 presets per component, making it difficult to showcase the full range of data formatting capabilities. These new presets demonstrate different column types, layout patterns, and use cases.

## How

**DataTable (7 new presets):**
- `hardware` - E-commerce catalog with currency, stock levels, badges
- `metrics` - Analytics dashboard with percentages, deltas, compact numbers
- `ledger` - Financial tracking with budgets, status indicators
- `milestones` - Timeline with date formatting, significance levels
- `archives` - File browser with sizes, types, permissions
- `inventory` - Stock management with quantity alerts
- `largeDataset` - 120 rows for scroll/performance testing

**MediaCard (8 new presets):**
- `portrait` - 9:16 vertical format
- `square` - 1:1 social media format
- `podcast` - Long-form audio with episode metadata
- `product` - E-commerce with add-to-cart actions
- `document` - PDF/document link preview
- `screenshot` - Auto-ratio with minimal metadata
- `gallery` - Carousel-ready with position indicator
- `edgeCases` - Missing optional fields

**OptionList (7 new presets):**
- `approval` - Multi-select checklist pattern
- `priority` - Single selection with impact levels
- `wizard` - Back/Next step navigation
- `destructive` - Delete confirmation with warnings
- `settings` - Preferences with toggle states
- `ranking` - Ordered selection
- `edgeCases` - Disabled items, long text

**SocialPost (6 new presets):**
- `video`, `thread`, `reel`, `longForm`, `minimal`, `maxContent`

Also updated `preset-selector.tsx` to display all new presets in the docs UI sidebar.

## Testing
- [x] TypeScript compiles without errors
- [x] All presets render correctly in the docs preview
- [x] Preset selector shows all new options
- [x] Verified visually using Playwright

## Checklist
- [x] Code follows existing patterns
- [x] No breaking changes to existing presets