### PR TITLE
feat: add CodeBlock and Terminal tool-ui components

### DIFF
--- a/app/docs/[component]/previews/code-block-preview.tsx
+++ b/app/docs/[component]/previews/code-block-preview.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useState, useEffect } from "react";
+import { useSearchParams, usePathname, useRouter } from "next/navigation";
+import { ComponentPreviewShell } from "../component-preview-shell";
+import { PresetSelector } from "../../_components/preset-selector";
+import { CodePanel } from "../../_components/code-panel";
+import { CodeBlock } from "@/components/tool-ui/code-block";
+import {
+  CodeBlockPresetName,
+  codeBlockPresets,
+} from "@/lib/presets/code-block";
+
+export function CodeBlockPreview({
+  withContainer = true,
+}: {
+  withContainer?: boolean;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const presetParam = searchParams.get("preset");
+  const defaultPreset = "typescript";
+  const initialPreset: CodeBlockPresetName =
+    presetParam && presetParam in codeBlockPresets
+      ? (presetParam as CodeBlockPresetName)
+      : defaultPreset;
+
+  const [currentPreset, setCurrentPreset] =
+    useState<CodeBlockPresetName>(initialPreset);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const presetParam = searchParams.get("preset");
+    if (
+      presetParam &&
+      presetParam in codeBlockPresets &&
+      presetParam !== currentPreset
+    ) {
+      setCurrentPreset(presetParam as CodeBlockPresetName);
+      setIsLoading(false);
+    }
+  }, [searchParams, currentPreset]);
+
+  const currentConfig = codeBlockPresets[currentPreset];
+
+  const handleSelectPreset = useCallback(
+    (preset: unknown) => {
+      const presetName = preset as CodeBlockPresetName;
+      setCurrentPreset(presetName);
+      setIsLoading(false);
+
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("preset", presetName);
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
+
+  const handleFooterAction = useCallback(async (actionId: string) => {
+    console.log("Footer action:", actionId);
+  }, []);
+
+  return (
+    <ComponentPreviewShell
+      withContainer={withContainer}
+      isLoading={isLoading}
+      onLoadingChange={setIsLoading}
+      presetSelector={
+        <PresetSelector
+          componentId="code-block"
+          currentPreset={currentPreset}
+          onSelectPreset={handleSelectPreset}
+        />
+      }
+      renderPreview={(isLoadingState) => (
+        <div className="w-full">
+          <CodeBlock
+            {...currentConfig.codeBlock}
+            surfaceId="code-block-preview"
+            onFooterAction={handleFooterAction}
+            isLoading={isLoadingState}
+          />
+        </div>
+      )}
+      renderCodePanel={() => (
+        <CodePanel
+          className="h-full w-full"
+          componentId="code-block"
+          codeBlockConfig={currentConfig}
+          mode="plain"
+        />
+      )}
+    />
+  );
+}

--- a/app/docs/[component]/previews/terminal-preview.tsx
+++ b/app/docs/[component]/previews/terminal-preview.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useState, useEffect } from "react";
+import { useSearchParams, usePathname, useRouter } from "next/navigation";
+import { ComponentPreviewShell } from "../component-preview-shell";
+import { PresetSelector } from "../../_components/preset-selector";
+import { CodePanel } from "../../_components/code-panel";
+import { Terminal } from "@/components/tool-ui/terminal";
+import { TerminalPresetName, terminalPresets } from "@/lib/presets/terminal";
+
+export function TerminalPreview({
+  withContainer = true,
+}: {
+  withContainer?: boolean;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const presetParam = searchParams.get("preset");
+  const defaultPreset = "success";
+  const initialPreset: TerminalPresetName =
+    presetParam && presetParam in terminalPresets
+      ? (presetParam as TerminalPresetName)
+      : defaultPreset;
+
+  const [currentPreset, setCurrentPreset] =
+    useState<TerminalPresetName>(initialPreset);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const presetParam = searchParams.get("preset");
+    if (
+      presetParam &&
+      presetParam in terminalPresets &&
+      presetParam !== currentPreset
+    ) {
+      setCurrentPreset(presetParam as TerminalPresetName);
+      setIsLoading(false);
+    }
+  }, [searchParams, currentPreset]);
+
+  const currentConfig = terminalPresets[currentPreset];
+
+  const handleSelectPreset = useCallback(
+    (preset: unknown) => {
+      const presetName = preset as TerminalPresetName;
+      setCurrentPreset(presetName);
+      setIsLoading(false);
+
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("preset", presetName);
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
+
+  const handleFooterAction = useCallback(async (actionId: string) => {
+    console.log("Footer action:", actionId);
+  }, []);
+
+  return (
+    <ComponentPreviewShell
+      withContainer={withContainer}
+      isLoading={isLoading}
+      onLoadingChange={setIsLoading}
+      presetSelector={
+        <PresetSelector
+          componentId="terminal"
+          currentPreset={currentPreset}
+          onSelectPreset={handleSelectPreset}
+        />
+      }
+      renderPreview={(isLoadingState) => (
+        <div className="w-full">
+          <Terminal
+            {...currentConfig.terminal}
+            surfaceId="terminal-preview"
+            onFooterAction={handleFooterAction}
+            isLoading={isLoadingState}
+          />
+        </div>
+      )}
+      renderCodePanel={() => (
+        <CodePanel
+          className="h-full w-full"
+          componentId="terminal"
+          terminalConfig={currentConfig}
+          mode="plain"
+        />
+      )}
+    />
+  );
+}

--- a/app/docs/_components/code-panel.tsx
+++ b/app/docs/_components/code-panel.tsx
@@ -4,6 +4,8 @@ import { DataTableConfig } from "@/lib/presets/data-table";
 import { SocialPostConfig } from "@/lib/presets/social-post";
 import { MediaCardConfig } from "@/lib/presets/media-card";
 import { OptionListConfig } from "@/lib/presets/option-list";
+import { CodeBlockConfig } from "@/lib/presets/code-block";
+import { TerminalConfig } from "@/lib/presets/terminal";
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 
 interface CodePanelProps {
@@ -12,6 +14,8 @@ interface CodePanelProps {
   socialPostConfig?: SocialPostConfig;
   mediaCardConfig?: MediaCardConfig;
   optionListConfig?: OptionListConfig;
+  codeBlockConfig?: CodeBlockConfig;
+  terminalConfig?: TerminalConfig;
   optionListSelection?: string[] | string | null;
   mediaCardMaxWidth?: string;
   sort?: { by?: string; direction?: "asc" | "desc" };
@@ -27,6 +31,8 @@ export function CodePanel({
   socialPostConfig,
   mediaCardConfig,
   optionListConfig,
+  codeBlockConfig,
+  terminalConfig,
   optionListSelection,
   mediaCardMaxWidth,
   sort,
@@ -76,7 +82,9 @@ export function CodePanel({
       props.push(
         `  footerActions={${JSON.stringify(config.footerActions, null, 4).replace(/\n/g, "\n  ")}}`,
       );
-      props.push(`  onFooterAction={(actionId) => console.log("Action:", actionId)}`);
+      props.push(
+        `  onFooterAction={(actionId) => console.log("Action:", actionId)}`,
+      );
     }
 
     // Generate sorting guidance only when relying on controlled state
@@ -246,11 +254,16 @@ export function CodePanel({
       props.push(`  isLoading={true}`);
     }
 
-    if (mediaCardConfig.footerActions && mediaCardConfig.footerActions.length > 0) {
+    if (
+      mediaCardConfig.footerActions &&
+      mediaCardConfig.footerActions.length > 0
+    ) {
       props.push(
         `  footerActions={${JSON.stringify(mediaCardConfig.footerActions, null, 4).replace(/\n/g, "\n  ")}}`,
       );
-      props.push(`  onFooterAction={(actionId) => console.log("Action:", actionId)}`);
+      props.push(
+        `  onFooterAction={(actionId) => console.log("Action:", actionId)}`,
+      );
     }
 
     return `<MediaCard\n${props.join("\n")}\n/>`;
@@ -294,6 +307,77 @@ export function CodePanel({
     return `<OptionList\n${props.join("\n")}\n/>`;
   };
 
+  const generateCodeBlockCode = () => {
+    if (!codeBlockConfig) return "";
+    const block = codeBlockConfig.codeBlock;
+    const props: string[] = [];
+
+    props.push(`  code={\`${escape(block.code)}\`}`);
+    props.push(`  language="${block.language}"`);
+
+    if (block.filename) {
+      props.push(`  filename="${block.filename}"`);
+    }
+
+    if (block.showLineNumbers !== undefined) {
+      props.push(`  showLineNumbers={${block.showLineNumbers}}`);
+    }
+
+    if (block.highlightLines && block.highlightLines.length > 0) {
+      props.push(`  highlightLines={[${block.highlightLines.join(", ")}]}`);
+    }
+
+    if (block.maxCollapsedLines) {
+      props.push(`  maxCollapsedLines={${block.maxCollapsedLines}}`);
+    }
+
+    if (isLoading) {
+      props.push(`  isLoading={true}`);
+    }
+
+    return `<CodeBlock\n${props.join("\n")}\n/>`;
+  };
+
+  const generateTerminalCode = () => {
+    if (!terminalConfig) return "";
+    const term = terminalConfig.terminal;
+    const props: string[] = [];
+
+    props.push(`  command="${escape(term.command)}"`);
+
+    if (term.stdout) {
+      props.push(`  stdout={\`${escape(term.stdout)}\`}`);
+    }
+
+    if (term.stderr) {
+      props.push(`  stderr={\`${escape(term.stderr)}\`}`);
+    }
+
+    props.push(`  exitCode={${term.exitCode}}`);
+
+    if (term.durationMs !== undefined) {
+      props.push(`  durationMs={${term.durationMs}}`);
+    }
+
+    if (term.cwd) {
+      props.push(`  cwd="${term.cwd}"`);
+    }
+
+    if (term.truncated) {
+      props.push(`  truncated={${term.truncated}}`);
+    }
+
+    if (term.maxCollapsedLines) {
+      props.push(`  maxCollapsedLines={${term.maxCollapsedLines}}`);
+    }
+
+    if (isLoading) {
+      props.push(`  isLoading={true}`);
+    }
+
+    return `<Terminal\n${props.join("\n")}\n/>`;
+  };
+
   const generateCode = () => {
     if (componentId === "data-table") {
       return generateDataTableCode();
@@ -303,6 +387,10 @@ export function CodePanel({
       return generateMediaCardCode();
     } else if (componentId === "option-list") {
       return generateOptionListCode();
+    } else if (componentId === "code-block") {
+      return generateCodeBlockCode();
+    } else if (componentId === "terminal") {
+      return generateTerminalCode();
     }
     return "";
   };

--- a/app/docs/_components/preset-example.tsx
+++ b/app/docs/_components/preset-example.tsx
@@ -3,11 +3,23 @@
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { OptionList } from "@/components/tool-ui/option-list";
+import { CodeBlock } from "@/components/tool-ui/code-block";
+import { Terminal } from "@/components/tool-ui/terminal";
 import {
   optionListPresets,
   OptionListPresetName,
   OptionListConfig,
 } from "@/lib/presets/option-list";
+import {
+  codeBlockPresets,
+  CodeBlockPresetName,
+  CodeBlockConfig,
+} from "@/lib/presets/code-block";
+import {
+  terminalPresets,
+  TerminalPresetName,
+  TerminalConfig,
+} from "@/lib/presets/terminal";
 
 function generateOptionListCode(config: OptionListConfig): string {
   const list = config.optionList;
@@ -57,6 +69,67 @@ function generateOptionListCode(config: OptionListConfig): string {
   return `<OptionList\n${props.join("\n")}\n/>`;
 }
 
+function generateCodeBlockCode(config: CodeBlockConfig): string {
+  const block = config.codeBlock;
+  const props: string[] = [];
+
+  props.push(`  code={\`${block.code.replace(/`/g, "\\`")}\`}`);
+  props.push(`  language="${block.language}"`);
+
+  if (block.filename) {
+    props.push(`  filename="${block.filename}"`);
+  }
+
+  if (block.showLineNumbers !== undefined) {
+    props.push(`  showLineNumbers={${block.showLineNumbers}}`);
+  }
+
+  if (block.highlightLines && block.highlightLines.length > 0) {
+    props.push(`  highlightLines={[${block.highlightLines.join(", ")}]}`);
+  }
+
+  if (block.maxCollapsedLines) {
+    props.push(`  maxCollapsedLines={${block.maxCollapsedLines}}`);
+  }
+
+  return `<CodeBlock\n${props.join("\n")}\n/>`;
+}
+
+function generateTerminalCode(config: TerminalConfig): string {
+  const term = config.terminal;
+  const props: string[] = [];
+
+  props.push(`  command="${term.command.replace(/"/g, '\\"')}"`);
+
+  if (term.stdout) {
+    props.push(`  stdout={\`${term.stdout.replace(/`/g, "\\`")}\`}`);
+  }
+
+  if (term.stderr) {
+    props.push(`  stderr={\`${term.stderr.replace(/`/g, "\\`")}\`}`);
+  }
+
+  props.push(`  exitCode={${term.exitCode}}`);
+
+  if (term.durationMs !== undefined) {
+    props.push(`  durationMs={${term.durationMs}}`);
+  }
+
+  if (term.cwd) {
+    props.push(`  cwd="${term.cwd}"`);
+  }
+
+  if (term.truncated) {
+    props.push(`  truncated={${term.truncated}}`);
+  }
+
+  if (term.maxCollapsedLines) {
+    props.push(`  maxCollapsedLines={${term.maxCollapsedLines}}`);
+  }
+
+  return `<Terminal\n${props.join("\n")}\n/>`;
+}
+
 interface OptionListPresetExampleProps {
   preset: OptionListPresetName;
 }
@@ -72,6 +145,52 @@ export function OptionListPresetExample({
       <Tab value="Preview">
         <div className="not-prose">
           <OptionList {...config.optionList} />
+        </div>
+      </Tab>
+      <Tab value="Code">
+        <DynamicCodeBlock lang="tsx" code={code} />
+      </Tab>
+    </Tabs>
+  );
+}
+
+interface CodeBlockPresetExampleProps {
+  preset: CodeBlockPresetName;
+}
+
+export function CodeBlockPresetExample({
+  preset,
+}: CodeBlockPresetExampleProps) {
+  const config = codeBlockPresets[preset];
+  const code = generateCodeBlockCode(config);
+
+  return (
+    <Tabs items={["Preview", "Code"]}>
+      <Tab value="Preview">
+        <div className="not-prose">
+          <CodeBlock {...config.codeBlock} />
+        </div>
+      </Tab>
+      <Tab value="Code">
+        <DynamicCodeBlock lang="tsx" code={code} />
+      </Tab>
+    </Tabs>
+  );
+}
+
+interface TerminalPresetExampleProps {
+  preset: TerminalPresetName;
+}
+
+export function TerminalPresetExample({ preset }: TerminalPresetExampleProps) {
+  const config = terminalPresets[preset];
+  const code = generateTerminalCode(config);
+
+  return (
+    <Tabs items={["Preview", "Code"]}>
+      <Tab value="Preview">
+        <div className="not-prose">
+          <Terminal {...config.terminal} />
         </div>
       </Tab>
       <Tab value="Code">

--- a/app/docs/_components/preset-selector.tsx
+++ b/app/docs/_components/preset-selector.tsx
@@ -14,9 +14,22 @@ import {
   OptionListPresetName,
   optionListPresetDescriptions,
 } from "@/lib/presets/option-list";
+import {
+  CodeBlockPresetName,
+  codeBlockPresetDescriptions,
+} from "@/lib/presets/code-block";
+import {
+  TerminalPresetName,
+  terminalPresetDescriptions,
+} from "@/lib/presets/terminal";
 import { cn } from "@/lib/ui/cn";
 
-type ComponentPreset = PresetName | MediaCardPresetName | OptionListPresetName;
+type ComponentPreset =
+  | PresetName
+  | MediaCardPresetName
+  | OptionListPresetName
+  | CodeBlockPresetName
+  | TerminalPresetName;
 
 interface PresetSelectorProps {
   componentId: string;
@@ -47,6 +60,24 @@ const optionListPresetNames: OptionListPresetName[] = [
   "actions",
 ];
 
+const codeBlockPresetNames: CodeBlockPresetName[] = [
+  "typescript",
+  "python",
+  "json",
+  "bash",
+  "highlighted",
+  "collapsible",
+];
+
+const terminalPresetNames: TerminalPresetName[] = [
+  "success",
+  "error",
+  "build",
+  "ansiColors",
+  "collapsible",
+  "noOutput",
+];
+
 export function PresetSelector({
   componentId,
   currentPreset,
@@ -57,14 +88,26 @@ export function PresetSelector({
       ? dataTablePresetNames
       : componentId === "media-card"
         ? mediaCardPresetNames
-        : optionListPresetNames;
+        : componentId === "option-list"
+          ? optionListPresetNames
+          : componentId === "code-block"
+            ? codeBlockPresetNames
+            : componentId === "terminal"
+              ? terminalPresetNames
+              : optionListPresetNames;
 
   const descriptions =
     componentId === "data-table"
       ? presetDescriptions
       : componentId === "media-card"
         ? mediaCardPresetDescriptions
-        : optionListPresetDescriptions;
+        : componentId === "option-list"
+          ? optionListPresetDescriptions
+          : componentId === "code-block"
+            ? codeBlockPresetDescriptions
+            : componentId === "terminal"
+              ? terminalPresetDescriptions
+              : optionListPresetDescriptions;
 
   return (
     <ItemGroup className="gap-1">

--- a/app/docs/code-block/content.mdx
+++ b/app/docs/code-block/content.mdx
@@ -1,0 +1,132 @@
+import { DocsHeader } from "../_components/docs-header";
+
+<DocsHeader title="Code Block" mdxPath="app/docs/code-block/content.mdx" />
+
+A syntax-highlighted code display component with copy functionality and collapsible mode. Perfect for showing code snippets, examples, and technical content.
+
+<CodeBlockPresetExample preset="typescript" />
+
+## Key Features
+
+- **Syntax highlighting**: Powered by Shiki with support for 100+ languages
+- **Copy to clipboard**: One-click code copying with visual feedback
+- **Line numbers**: Optional line number display
+- **Line highlighting**: Highlight specific lines (useful for bug indicators)
+- **Collapsible mode**: Auto-collapse long code snippets with expand/collapse
+- **Filename header**: Optional filename display with language badge
+- **Theme aware**: Automatically adapts to light/dark theme
+
+## When to Use Code Block
+
+- **Good for:** Code examples, configuration files, API responses, scripts
+- **Not for:** Interactive code editing (use CodeMirror), large files (consider linking)
+
+## Props
+
+### Core Props
+
+- `code` (string, required): The code content to display
+- `language` (string, default: "text"): Programming language for syntax highlighting
+- `filename` (string, optional): Filename to display in the header
+
+### Display Options
+
+- `showLineNumbers` (boolean, default: true): Show line numbers
+- `highlightLines` (number[], optional): Array of line numbers to highlight
+- `maxCollapsedLines` (number, optional): Auto-collapse if code exceeds this many lines
+
+### Standard Props
+
+- `surfaceId` (string, required): Unique identifier for this surface
+- `footerActions` (Action[], optional): Footer action buttons
+- `className` (string, optional): Additional CSS classes
+- `isLoading` (boolean, optional): Show loading skeleton state
+
+## Examples
+
+### Basic TypeScript
+
+<CodeBlockPresetExample preset="typescript" />
+
+### Python with Docstring
+
+<CodeBlockPresetExample preset="python" />
+
+### JSON Configuration
+
+<CodeBlockPresetExample preset="json" />
+
+### Bash Script
+
+<CodeBlockPresetExample preset="bash" />
+
+### Highlighted Lines
+
+<CodeBlockPresetExample preset="highlighted" />
+
+### Collapsible Long Code
+
+<CodeBlockPresetExample preset="collapsible" />
+
+## Source and Install
+
+Copy `components/tool-ui/code-block` into your project:
+
+<Files>
+  <Folder name="components" defaultOpen>
+    <Folder name="tool-ui" defaultOpen>
+      <Folder name="code-block" defaultOpen>
+        <File name="code-block.tsx" />
+        <File name="schema.ts" />
+        <File name="index.tsx" />
+        <File name="progress.tsx" />
+        <File name="_ui.tsx" />
+        <File name="_cn.ts" />
+      </Folder>
+    </Folder>
+  </Folder>
+</Files>
+
+Install dependencies:
+
+```bash
+pnpm add shiki
+```
+
+## Usage
+
+```tsx
+import { CodeBlock } from "@/components/tool-ui/code-block";
+
+export function MyComponent() {
+  return (
+    <CodeBlock
+      surfaceId="my-code-example"
+      code={`function hello(name: string) {
+  return \`Hello, \${name}!\`;
+}`}
+      language="typescript"
+      filename="hello.ts"
+      showLineNumbers={true}
+    />
+  );
+}
+```
+
+## Supported Languages
+
+CodeBlock supports all languages included with Shiki, including:
+
+- TypeScript/JavaScript
+- Python
+- JSON
+- Bash/Shell
+- CSS/HTML
+- Markdown
+- SQL
+- YAML
+- Go
+- Rust
+- And many more...
+
+See [Shiki documentation](https://shiki.style/languages) for the complete list.

--- a/app/docs/code-block/page.tsx
+++ b/app/docs/code-block/page.tsx
@@ -1,0 +1,13 @@
+import Content from "./content.mdx";
+import { ComponentDocsExamples } from "../_components/component-docs-examples";
+import { CodeBlockPreview } from "../[component]/previews/code-block-preview";
+
+export default function CodeBlockDocsPage() {
+  return (
+    <ComponentDocsExamples
+      docs={<Content />}
+      examples={<CodeBlockPreview withContainer={false} />}
+      defaultTab="docs"
+    />
+  );
+}

--- a/app/docs/terminal/content.mdx
+++ b/app/docs/terminal/content.mdx
@@ -1,0 +1,158 @@
+import { DocsHeader } from "../_components/docs-header";
+
+<DocsHeader title="Terminal" mdxPath="app/docs/terminal/content.mdx" />
+
+A command output display component with ANSI color support, exit codes, and duration tracking. Perfect for showing command results, build outputs, and terminal interactions.
+
+<TerminalPresetExample preset="success" />
+
+## Key Features
+
+- **ANSI color support**: Renders colored terminal output correctly
+- **Exit code display**: Visual success/failure indicators
+- **Command display**: Shows the executed command with working directory
+- **Duration tracking**: Displays command execution time
+- **Stdout/Stderr separation**: Different styling for errors
+- **Copy functionality**: Separate copy buttons for command and output
+- **Collapsible mode**: Auto-collapse long output with expand/collapse
+- **Loading states**: Skeleton loading during command execution
+
+## When to Use Terminal
+
+- **Good for:** Build outputs, test results, command responses, CI/CD logs
+- **Not for:** Interactive terminal sessions (use xterm.js), real-time streaming
+
+## Props
+
+### Core Props
+
+- `command` (string, required): The command that was executed
+- `stdout` (string, optional): Standard output content
+- `stderr` (string, optional): Standard error content
+- `exitCode` (number, required): Process exit code (0 = success)
+
+### Metadata
+
+- `durationMs` (number, optional): Command execution time in milliseconds
+- `cwd` (string, optional): Working directory where command ran
+- `truncated` (boolean, optional): Indicates output was truncated
+
+### Display Options
+
+- `maxCollapsedLines` (number, optional): Auto-collapse if output exceeds this many lines
+
+### Standard Props
+
+- `surfaceId` (string, required): Unique identifier for this surface
+- `footerActions` (Action[], optional): Footer action buttons
+- `className` (string, optional): Additional CSS classes
+- `isLoading` (boolean, optional): Show loading skeleton state
+
+## Examples
+
+### Successful Test Run
+
+<TerminalPresetExample preset="success" />
+
+### Failed Build with Error
+
+<TerminalPresetExample preset="error" />
+
+### Docker Build Output
+
+<TerminalPresetExample preset="build" />
+
+### ANSI Colored Output
+
+<TerminalPresetExample preset="ansiColors" />
+
+### Collapsible Long Output
+
+<TerminalPresetExample preset="collapsible" />
+
+### Command with No Output
+
+<TerminalPresetExample preset="noOutput" />
+
+## ANSI Color Support
+
+Terminal automatically renders ANSI escape codes for colored output:
+
+```tsx
+import { Terminal } from "@/components/tool-ui/terminal";
+
+const coloredOutput = "\x1b[32m✔\x1b[0m Success\n\x1b[31m✗\x1b[0m Error";
+
+<Terminal
+  surfaceId="my-terminal"
+  command="npm test"
+  stdout={coloredOutput}
+  exitCode={0}
+/>;
+```
+
+Common ANSI codes:
+
+- `\x1b[32m` - Green text
+- `\x1b[31m` - Red text
+- `\x1b[33m` - Yellow text
+- `\x1b[36m` - Cyan text
+- `\x1b[1m` - Bold text
+- `\x1b[0m` - Reset formatting
+
+## Source and Install
+
+Copy `components/tool-ui/terminal` into your project:
+
+<Files>
+  <Folder name="components" defaultOpen>
+    <Folder name="tool-ui" defaultOpen>
+      <Folder name="terminal" defaultOpen>
+        <File name="terminal.tsx" />
+        <File name="schema.ts" />
+        <File name="index.tsx" />
+        <File name="progress.tsx" />
+        <File name="_ui.tsx" />
+        <File name="_cn.ts" />
+      </Folder>
+    </Folder>
+  </Folder>
+</Files>
+
+Install dependencies:
+
+```bash
+pnpm add ansi-to-react
+```
+
+## Usage
+
+```tsx
+import { Terminal } from "@/components/tool-ui/terminal";
+
+export function MyComponent() {
+  return (
+    <Terminal
+      surfaceId="my-terminal-example"
+      command="ls -la"
+      stdout="total 16
+drwxr-xr-x  3 user user 4096 Dec  3 10:23 .
+drwxr-xr-x 12 user user 4096 Dec  3 10:20 ..
+-rw-r--r--  1 user user  220 Dec  3 10:23 package.json"
+      exitCode={0}
+      durationMs={45}
+      cwd="~/project"
+    />
+  );
+}
+```
+
+## Exit Code Meanings
+
+- `0` - Success (green badge)
+- `1` - General error (red badge)
+- `2` - Misuse of shell builtins (red badge)
+- `126` - Command not executable (red badge)
+- `127` - Command not found (red badge)
+- `130` - Interrupted with Ctrl+C (red badge)
+- Any non-zero - Error (red badge)

--- a/app/docs/terminal/page.tsx
+++ b/app/docs/terminal/page.tsx
@@ -1,0 +1,13 @@
+import Content from "./content.mdx";
+import { ComponentDocsExamples } from "../_components/component-docs-examples";
+import { TerminalPreview } from "../[component]/previews/terminal-preview";
+
+export default function TerminalDocsPage() {
+  return (
+    <ComponentDocsExamples
+      docs={<Content />}
+      examples={<TerminalPreview withContainer={false} />}
+      defaultTab="docs"
+    />
+  );
+}

--- a/components/tool-ui/code-block/_cn.ts
+++ b/components/tool-ui/code-block/_cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/components/tool-ui/code-block/_ui.tsx
+++ b/components/tool-ui/code-block/_ui.tsx
@@ -1,0 +1,4 @@
+"use client";
+
+export { Button } from "../../ui/button";
+export { Collapsible, CollapsibleTrigger } from "@radix-ui/react-collapsible";

--- a/components/tool-ui/code-block/code-block.tsx
+++ b/components/tool-ui/code-block/code-block.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useMemo, useState, useCallback, useEffect } from "react";
+import { codeToHtml } from "shiki";
+import { useTheme } from "next-themes";
+import { Copy, Check, ChevronDown, ChevronUp } from "lucide-react";
+import type { CodeBlockProps } from "./schema";
+import { ActionButtons, normalizeActionsConfig } from "../shared";
+import { Button, Collapsible, CollapsibleTrigger } from "./_ui";
+import { cn } from "./_cn";
+import { CodeBlockProgress } from "./progress";
+
+const LANGUAGE_DISPLAY_NAMES: Record<string, string> = {
+  typescript: "TypeScript",
+  javascript: "JavaScript",
+  python: "Python",
+  tsx: "TSX",
+  jsx: "JSX",
+  json: "JSON",
+  bash: "Bash",
+  shell: "Shell",
+  css: "CSS",
+  html: "HTML",
+  markdown: "Markdown",
+  sql: "SQL",
+  yaml: "YAML",
+  go: "Go",
+  rust: "Rust",
+  text: "Plain Text",
+};
+
+function getLanguageDisplayName(lang: string): string {
+  return LANGUAGE_DISPLAY_NAMES[lang.toLowerCase()] || lang.toUpperCase();
+}
+
+function useCopyToClipboard() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+  }, []);
+
+  useEffect(() => {
+    if (copied) {
+      const timeout = setTimeout(() => setCopied(false), 2000);
+      return () => clearTimeout(timeout);
+    }
+  }, [copied]);
+
+  return { copied, copy };
+}
+
+export function CodeBlock({
+  surfaceId,
+  code,
+  language = "text",
+  filename,
+  showLineNumbers = true,
+  highlightLines,
+  maxCollapsedLines,
+  footerActions,
+  onFooterAction,
+  onBeforeFooterAction,
+  isLoading,
+  className,
+}: CodeBlockProps) {
+  const { theme: browserTheme } = useTheme();
+  const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
+
+  const theme = browserTheme === "dark" ? "github-dark" : "github-light";
+
+  // Generate highlighted HTML
+  useEffect(() => {
+    async function highlight() {
+      if (!code) {
+        setHighlightedHtml("");
+        return;
+      }
+
+      try {
+        const html = await codeToHtml(code, {
+          lang: language,
+          theme,
+          transformers: [
+            {
+              line(node, line) {
+                // Add line number data attribute
+                node.properties["data-line"] = line;
+                // Add highlight class if line is in highlightLines
+                if (highlightLines?.includes(line)) {
+                  node.properties["class"] =
+                    `${node.properties["class"] || ""} highlighted-line`;
+                }
+              },
+            },
+          ],
+        });
+        setHighlightedHtml(html);
+      } catch {
+        // Fallback for unknown languages
+        const escaped = code
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+        setHighlightedHtml(`<pre><code>${escaped}</code></pre>`);
+      }
+    }
+    highlight();
+  }, [code, language, theme, highlightLines]);
+
+  const normalizedFooterActions = useMemo(
+    () => normalizeActionsConfig(footerActions),
+    [footerActions],
+  );
+
+  const lineCount = code.split("\n").length;
+  const shouldCollapse = maxCollapsedLines && lineCount > maxCollapsedLines;
+  const isCollapsed = shouldCollapse && !isExpanded;
+
+  const handleCopy = useCallback(() => {
+    copy(code);
+  }, [code, copy]);
+
+  if (isLoading) {
+    return (
+      <div
+        className={cn("@container flex w-full flex-col gap-3", className)}
+        data-surface-id={surfaceId}
+        aria-busy="true"
+      >
+        <div className="border-border bg-card overflow-hidden rounded-lg border shadow-xs">
+          <CodeBlockProgress />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("@container flex w-full flex-col gap-3", className)}
+      data-surface-id={surfaceId}
+      data-slot="code-block"
+    >
+      <div className="border-border bg-card overflow-hidden rounded-lg border shadow-xs">
+        {/* Header */}
+        <div className="bg-muted/50 flex items-center justify-between border-b px-4 py-2">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-xs font-medium">
+              {getLanguageDisplayName(language)}
+            </span>
+            {filename && (
+              <>
+                <span className="text-muted-foreground/50">•</span>
+                <span className="text-foreground text-xs font-medium">
+                  {filename}
+                </span>
+              </>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCopy}
+            className="h-7 w-7 p-0"
+            aria-label={copied ? "Copied" : "Copy code"}
+          >
+            {copied ? (
+              <Check className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="text-muted-foreground h-4 w-4" />
+            )}
+          </Button>
+        </div>
+
+        {/* Code content */}
+        <Collapsible open={!isCollapsed}>
+          <div
+            className={cn(
+              "overflow-x-auto text-sm",
+              showLineNumbers && "[&_.line]:pl-4 [&_pre]:pl-0",
+              "[&_pre]:m-0 [&_pre]:bg-transparent [&_pre]:p-4",
+              "[&_.highlighted-line]:bg-primary/10 [&_.highlighted-line]:border-primary [&_.highlighted-line]:border-l-2",
+              isCollapsed && "max-h-[200px] overflow-hidden",
+            )}
+          >
+            {highlightedHtml ? (
+              <div dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
+            ) : (
+              <pre className="p-4">
+                <code>{code}</code>
+              </pre>
+            )}
+          </div>
+
+          {shouldCollapse && (
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="w-full rounded-none border-t py-2"
+              >
+                {isCollapsed ? (
+                  <>
+                    <ChevronDown className="mr-2 h-4 w-4" />
+                    Show all {lineCount} lines
+                  </>
+                ) : (
+                  <>
+                    <ChevronUp className="mr-2 h-4 w-4" />
+                    Collapse
+                  </>
+                )}
+              </Button>
+            </CollapsibleTrigger>
+          )}
+        </Collapsible>
+      </div>
+
+      {/* Footer actions */}
+      {normalizedFooterActions && (
+        <div className="@container/actions">
+          <ActionButtons
+            actions={normalizedFooterActions.items}
+            align={normalizedFooterActions.align}
+            confirmTimeout={normalizedFooterActions.confirmTimeout}
+            onAction={(id) => onFooterAction?.(id)}
+            onBeforeAction={onBeforeFooterAction}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/tool-ui/code-block/index.tsx
+++ b/components/tool-ui/code-block/index.tsx
@@ -1,0 +1,7 @@
+export { CodeBlock } from "./code-block";
+export type { CodeBlockProps, SerializableCodeBlock } from "./schema";
+export {
+  CodeBlockPropsSchema,
+  SerializableCodeBlockSchema,
+  parseSerializableCodeBlock,
+} from "./schema";

--- a/components/tool-ui/code-block/progress.tsx
+++ b/components/tool-ui/code-block/progress.tsx
@@ -1,0 +1,21 @@
+import { cn } from "./_cn";
+
+export function CodeBlockProgress({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex w-full animate-pulse flex-col gap-2", className)}>
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="bg-muted h-4 w-20 rounded" />
+        <div className="bg-muted h-6 w-6 rounded" />
+      </div>
+      {/* Code lines skeleton */}
+      <div className="flex flex-col gap-1.5 px-4 py-3">
+        <div className="bg-muted h-4 w-3/4 rounded" />
+        <div className="bg-muted h-4 w-1/2 rounded" />
+        <div className="bg-muted h-4 w-5/6 rounded" />
+        <div className="bg-muted h-4 w-2/3 rounded" />
+        <div className="bg-muted h-4 w-4/5 rounded" />
+      </div>
+    </div>
+  );
+}

--- a/components/tool-ui/code-block/schema.ts
+++ b/components/tool-ui/code-block/schema.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import {
+  SurfaceIdSchema,
+  SerializableActionSchema,
+  SerializableActionsConfigSchema,
+} from "../shared";
+
+export const CodeBlockPropsSchema = z.object({
+  surfaceId: SurfaceIdSchema,
+  code: z.string(),
+  language: z.string().default("text"),
+  filename: z.string().optional(),
+  showLineNumbers: z.boolean().default(true),
+  highlightLines: z.array(z.number()).optional(),
+  maxCollapsedLines: z.number().min(1).optional(),
+  footerActions: z
+    .union([z.array(SerializableActionSchema), SerializableActionsConfigSchema])
+    .optional(),
+  className: z.string().optional(),
+});
+
+export type CodeBlockProps = z.infer<typeof CodeBlockPropsSchema> & {
+  isLoading?: boolean;
+  onFooterAction?: (actionId: string) => void | Promise<void>;
+  onBeforeFooterAction?: (actionId: string) => boolean | Promise<boolean>;
+};
+
+export const SerializableCodeBlockSchema = CodeBlockPropsSchema.omit({
+  className: true,
+});
+
+export type SerializableCodeBlock = z.infer<typeof SerializableCodeBlockSchema>;
+
+export function parseSerializableCodeBlock(
+  input: unknown,
+): SerializableCodeBlock {
+  const res = SerializableCodeBlockSchema.safeParse(input);
+  if (!res.success) {
+    throw new Error(`Invalid CodeBlock payload: ${res.error.message}`);
+  }
+  return res.data;
+}

--- a/components/tool-ui/terminal/_cn.ts
+++ b/components/tool-ui/terminal/_cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/components/tool-ui/terminal/_ui.tsx
+++ b/components/tool-ui/terminal/_ui.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export { Button } from "../../ui/button";
+export { Badge } from "../../ui/badge";
+export { Collapsible, CollapsibleTrigger } from "@radix-ui/react-collapsible";

--- a/components/tool-ui/terminal/index.tsx
+++ b/components/tool-ui/terminal/index.tsx
@@ -1,0 +1,7 @@
+export { Terminal } from "./terminal";
+export type { TerminalProps, SerializableTerminal } from "./schema";
+export {
+  TerminalPropsSchema,
+  SerializableTerminalSchema,
+  parseSerializableTerminal,
+} from "./schema";

--- a/components/tool-ui/terminal/progress.tsx
+++ b/components/tool-ui/terminal/progress.tsx
@@ -1,0 +1,26 @@
+import { cn } from "./_cn";
+
+export function TerminalProgress({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex w-full animate-pulse flex-col", className)}>
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between bg-zinc-800 px-4 py-2">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-4 rounded bg-zinc-600" />
+          <div className="h-4 w-48 rounded bg-zinc-600" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-5 w-12 rounded bg-zinc-600" />
+          <div className="h-6 w-6 rounded bg-zinc-600" />
+        </div>
+      </div>
+      {/* Output skeleton */}
+      <div className="flex flex-col gap-1.5 bg-zinc-900 px-4 py-3">
+        <div className="h-4 w-3/4 rounded bg-zinc-700" />
+        <div className="h-4 w-1/2 rounded bg-zinc-700" />
+        <div className="h-4 w-5/6 rounded bg-zinc-700" />
+        <div className="h-4 w-2/3 rounded bg-zinc-700" />
+      </div>
+    </div>
+  );
+}

--- a/components/tool-ui/terminal/schema.ts
+++ b/components/tool-ui/terminal/schema.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import {
+  SurfaceIdSchema,
+  SerializableActionSchema,
+  SerializableActionsConfigSchema,
+} from "../shared";
+
+export const TerminalPropsSchema = z.object({
+  surfaceId: SurfaceIdSchema,
+  command: z.string(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  exitCode: z.number(),
+  durationMs: z.number().optional(),
+  cwd: z.string().optional(),
+  truncated: z.boolean().optional(),
+  maxCollapsedLines: z.number().min(1).optional(),
+  footerActions: z
+    .union([z.array(SerializableActionSchema), SerializableActionsConfigSchema])
+    .optional(),
+  className: z.string().optional(),
+});
+
+export type TerminalProps = z.infer<typeof TerminalPropsSchema> & {
+  isLoading?: boolean;
+  onFooterAction?: (actionId: string) => void | Promise<void>;
+  onBeforeFooterAction?: (actionId: string) => boolean | Promise<boolean>;
+};
+
+export const SerializableTerminalSchema = TerminalPropsSchema.omit({
+  className: true,
+});
+
+export type SerializableTerminal = z.infer<typeof SerializableTerminalSchema>;
+
+export function parseSerializableTerminal(
+  input: unknown,
+): SerializableTerminal {
+  const res = SerializableTerminalSchema.safeParse(input);
+  if (!res.success) {
+    throw new Error(`Invalid Terminal payload: ${res.error.message}`);
+  }
+  return res.data;
+}

--- a/components/tool-ui/terminal/terminal.tsx
+++ b/components/tool-ui/terminal/terminal.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useMemo, useState, useCallback, useEffect } from "react";
+import Ansi from "ansi-to-react";
+import {
+  Copy,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Terminal as TerminalIcon,
+  Clock,
+} from "lucide-react";
+import type { TerminalProps } from "./schema";
+import { ActionButtons, normalizeActionsConfig } from "../shared";
+import { Button, Badge, Collapsible, CollapsibleTrigger } from "./_ui";
+import { cn } from "./_cn";
+import { TerminalProgress } from "./progress";
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(ms / 60000);
+  const seconds = ((ms % 60000) / 1000).toFixed(0);
+  return `${minutes}m ${seconds}s`;
+}
+
+function useCopyToClipboard() {
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copy = useCallback(async (text: string, id: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(id);
+  }, []);
+
+  useEffect(() => {
+    if (copied) {
+      const timeout = setTimeout(() => setCopied(null), 2000);
+      return () => clearTimeout(timeout);
+    }
+  }, [copied]);
+
+  return { copied, copy };
+}
+
+export function Terminal({
+  surfaceId,
+  command,
+  stdout,
+  stderr,
+  exitCode,
+  durationMs,
+  cwd,
+  truncated,
+  maxCollapsedLines,
+  footerActions,
+  onFooterAction,
+  onBeforeFooterAction,
+  isLoading,
+  className,
+}: TerminalProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
+
+  const isSuccess = exitCode === 0;
+  const hasOutput = stdout || stderr;
+  const fullOutput = [stdout, stderr].filter(Boolean).join("\n");
+
+  const lineCount = fullOutput.split("\n").length;
+  const shouldCollapse = maxCollapsedLines && lineCount > maxCollapsedLines;
+  const isCollapsed = shouldCollapse && !isExpanded;
+
+  const normalizedFooterActions = useMemo(
+    () => normalizeActionsConfig(footerActions),
+    [footerActions],
+  );
+
+  const handleCopyCommand = useCallback(() => {
+    copy(command, "command");
+  }, [command, copy]);
+
+  const handleCopyOutput = useCallback(() => {
+    copy(fullOutput, "output");
+  }, [fullOutput, copy]);
+
+  if (isLoading) {
+    return (
+      <div
+        className={cn("@container flex w-full flex-col gap-3", className)}
+        data-surface-id={surfaceId}
+        aria-busy="true"
+      >
+        <div className="overflow-hidden rounded-lg border border-zinc-700 shadow-xs">
+          <TerminalProgress />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("@container flex w-full flex-col gap-3", className)}
+      data-surface-id={surfaceId}
+      data-slot="terminal"
+    >
+      <div className="overflow-hidden rounded-lg border border-zinc-700 shadow-xs">
+        {/* Header */}
+        <div className="flex items-center justify-between bg-zinc-800 px-4 py-2">
+          <div className="flex items-center gap-2 overflow-hidden">
+            <TerminalIcon className="h-4 w-4 shrink-0 text-zinc-400" />
+            <code className="truncate font-mono text-sm text-zinc-100">
+              {cwd && <span className="text-zinc-500">{cwd}$ </span>}
+              {command}
+            </code>
+          </div>
+          <div className="flex items-center gap-2">
+            {durationMs !== undefined && (
+              <span className="flex items-center gap-1 text-xs text-zinc-400">
+                <Clock className="h-3 w-3" />
+                {formatDuration(durationMs)}
+              </span>
+            )}
+            <Badge
+              variant={isSuccess ? "default" : "destructive"}
+              className={cn(
+                "font-mono text-xs",
+                isSuccess && "bg-green-600 hover:bg-green-600",
+              )}
+            >
+              {exitCode}
+            </Badge>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCopyCommand}
+              className="h-7 w-7 p-0 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-100"
+              aria-label={copied === "command" ? "Copied" : "Copy command"}
+            >
+              {copied === "command" ? (
+                <Check className="h-4 w-4 text-green-500" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {/* Output */}
+        {hasOutput && (
+          <Collapsible open={!isCollapsed}>
+            <div
+              className={cn(
+                "relative bg-zinc-900 font-mono text-sm",
+                isCollapsed && "max-h-[200px] overflow-hidden",
+              )}
+            >
+              <div className="overflow-x-auto p-4">
+                {stdout && (
+                  <div className="break-all whitespace-pre-wrap text-zinc-100">
+                    <Ansi>{stdout}</Ansi>
+                  </div>
+                )}
+                {stderr && (
+                  <div className="mt-2 break-all whitespace-pre-wrap text-red-400">
+                    <Ansi>{stderr}</Ansi>
+                  </div>
+                )}
+                {truncated && (
+                  <div className="mt-2 text-xs text-zinc-500 italic">
+                    Output truncated...
+                  </div>
+                )}
+              </div>
+
+              {/* Copy output button */}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleCopyOutput}
+                className="absolute top-2 right-2 h-7 w-7 p-0 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-100"
+                aria-label={copied === "output" ? "Copied" : "Copy output"}
+              >
+                {copied === "output" ? (
+                  <Check className="h-4 w-4 text-green-500" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+
+              {/* Collapsed gradient overlay */}
+              {isCollapsed && (
+                <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-zinc-900 to-transparent" />
+              )}
+            </div>
+
+            {shouldCollapse && (
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsExpanded(!isExpanded)}
+                  className="w-full rounded-none border-t border-zinc-700 bg-zinc-800 py-2 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-100"
+                >
+                  {isCollapsed ? (
+                    <>
+                      <ChevronDown className="mr-2 h-4 w-4" />
+                      Show all {lineCount} lines
+                    </>
+                  ) : (
+                    <>
+                      <ChevronUp className="mr-2 h-4 w-4" />
+                      Collapse
+                    </>
+                  )}
+                </Button>
+              </CollapsibleTrigger>
+            )}
+          </Collapsible>
+        )}
+
+        {/* No output state */}
+        {!hasOutput && (
+          <div className="bg-zinc-900 px-4 py-3 text-sm text-zinc-500 italic">
+            No output
+          </div>
+        )}
+      </div>
+
+      {/* Footer actions */}
+      {normalizedFooterActions && (
+        <div className="@container/actions">
+          <ActionButtons
+            actions={normalizedFooterActions.items}
+            align={normalizedFooterActions.align}
+            confirmTimeout={normalizedFooterActions.confirmTimeout}
+            onAction={(id) => onFooterAction?.(id)}
+            onBeforeAction={onBeforeFooterAction}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -606,10 +606,8 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean;
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  // Fixed width between 50 to 90% to avoid impure function warning
+  const width = "75%";
 
   return (
     <div

--- a/lib/docs/component-registry.ts
+++ b/lib/docs/component-registry.ts
@@ -6,14 +6,14 @@ export interface ComponentMeta {
 
 export const componentsRegistry: ComponentMeta[] = [
   {
+    id: "code-block",
+    label: "Code Block",
+    path: "/docs/code-block",
+  },
+  {
     id: "data-table",
     label: "Data Table",
     path: "/docs/data-table",
-  },
-  {
-    id: "option-list",
-    label: "Option List",
-    path: "/docs/option-list",
   },
   {
     id: "media-card",
@@ -21,9 +21,19 @@ export const componentsRegistry: ComponentMeta[] = [
     path: "/docs/media-card",
   },
   {
+    id: "option-list",
+    label: "Option List",
+    path: "/docs/option-list",
+  },
+  {
     id: "social-post",
     label: "Social Posts",
     path: "/docs/social-post",
+  },
+  {
+    id: "terminal",
+    label: "Terminal",
+    path: "/docs/terminal",
   },
 ];
 

--- a/lib/presets/code-block.ts
+++ b/lib/presets/code-block.ts
@@ -1,0 +1,149 @@
+import type { SerializableCodeBlock } from "@/components/tool-ui/code-block";
+
+export interface CodeBlockConfig {
+  codeBlock: SerializableCodeBlock;
+}
+
+export type CodeBlockPresetName =
+  | "typescript"
+  | "python"
+  | "json"
+  | "bash"
+  | "highlighted"
+  | "collapsible";
+
+const typescriptPreset: CodeBlockConfig = {
+  codeBlock: {
+    surfaceId: "code-block-preview-typescript",
+    code: `import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <button onClick={() => setCount(c => c + 1)}>
+      Count: {count}
+    </button>
+  );
+}`,
+    language: "typescript",
+    filename: "Counter.tsx",
+    showLineNumbers: true,
+  },
+};
+
+const pythonPreset: CodeBlockConfig = {
+  codeBlock: {
+    surfaceId: "code-block-preview-python",
+    code: `def fibonacci(n: int) -> list[int]:
+    """Generate Fibonacci sequence up to n terms."""
+    if n <= 0:
+        return []
+    elif n == 1:
+        return [0]
+
+    sequence = [0, 1]
+    while len(sequence) < n:
+        sequence.append(sequence[-1] + sequence[-2])
+
+    return sequence
+
+# Example usage
+print(fibonacci(10))`,
+    language: "python",
+    filename: "fibonacci.py",
+    showLineNumbers: true,
+  },
+};
+
+const jsonPreset: CodeBlockConfig = {
+  codeBlock: {
+    surfaceId: "code-block-preview-json",
+    code: `{
+  "name": "tool-ui",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^19.0.0",
+    "zod": "^4.0.0",
+    "shiki": "^3.0.0"
+  }
+}`,
+    language: "json",
+    filename: "package.json",
+    showLineNumbers: true,
+  },
+};
+
+const bashPreset: CodeBlockConfig = {
+  codeBlock: {
+    surfaceId: "code-block-preview-bash",
+    code: `#!/bin/bash
+# Deploy script
+
+echo "Building application..."
+pnpm run build
+
+echo "Running tests..."
+pnpm test
+
+echo "Deploying to production..."
+rsync -avz ./dist/ user@server:/var/www/app/
+
+echo "Done!"`,
+    language: "bash",
+    filename: "deploy.sh",
+    showLineNumbers: true,
+  },
+};
+
+const highlightedPreset: CodeBlockConfig = {
+  codeBlock: {
+    surfaceId: "code-block-preview-highlighted",
+    code: `function processData(items: string[]) {
+  const results = [];
+
+  for (const item of items) {
+    // BUG: This should handle null values
+    results.push(item.toUpperCase());
+  }
+
+  return results;
+}`,
+    language: "typescript",
+    filename: "processor.ts",
+    showLineNumbers: true,
+    highlightLines: [5, 6],
+  },
+};
+
+const collapsiblePreset: CodeBlockConfig = {
+  codeBlock: {
+    surfaceId: "code-block-preview-collapsible",
+    code: Array.from(
+      { length: 30 },
+      (_, i) => `console.log("Line ${i + 1}");`,
+    ).join("\n"),
+    language: "javascript",
+    showLineNumbers: true,
+    maxCollapsedLines: 10,
+  },
+};
+
+export const codeBlockPresets: Record<CodeBlockPresetName, CodeBlockConfig> = {
+  typescript: typescriptPreset,
+  python: pythonPreset,
+  json: jsonPreset,
+  bash: bashPreset,
+  highlighted: highlightedPreset,
+  collapsible: collapsiblePreset,
+};
+
+export const codeBlockPresetDescriptions: Record<CodeBlockPresetName, string> =
+  {
+    typescript: "TypeScript with filename header",
+    python: "Python function with docstring",
+    json: "JSON configuration file",
+    bash: "Bash script with comments",
+    highlighted: "Code with highlighted lines (bug indicator)",
+    collapsible: "Long code with collapse/expand",
+  };

--- a/lib/presets/terminal.ts
+++ b/lib/presets/terminal.ts
@@ -1,0 +1,132 @@
+import type { SerializableTerminal } from "@/components/tool-ui/terminal";
+
+export interface TerminalConfig {
+  terminal: SerializableTerminal;
+}
+
+export type TerminalPresetName =
+  | "success"
+  | "error"
+  | "build"
+  | "ansiColors"
+  | "collapsible"
+  | "noOutput";
+
+const successPreset: TerminalConfig = {
+  terminal: {
+    surfaceId: "terminal-preview-success",
+    command: "pnpm test",
+    stdout: `✓ src/utils.test.ts (5 tests) 23ms
+✓ src/api.test.ts (12 tests) 156ms
+✓ src/components.test.ts (8 tests) 89ms
+
+Test Files  3 passed (3)
+     Tests  25 passed (25)
+  Start at  10:23:45
+  Duration  312ms`,
+    exitCode: 0,
+    durationMs: 312,
+    cwd: "~/project",
+  },
+};
+
+const errorPreset: TerminalConfig = {
+  terminal: {
+    surfaceId: "terminal-preview-error",
+    command: "pnpm build",
+    stdout: `Building application...
+Compiling TypeScript...`,
+    stderr: `error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+
+  src/utils.ts:23:15
+    23   calculate(input);
+                  ~~~~~
+
+Found 1 error in src/utils.ts:23`,
+    exitCode: 1,
+    durationMs: 1523,
+    cwd: "~/project",
+  },
+};
+
+const buildPreset: TerminalConfig = {
+  terminal: {
+    surfaceId: "terminal-preview-build",
+    command: "docker build -t myapp:latest .",
+    stdout: `[+] Building 45.2s (12/12) FINISHED
+ => [internal] load build definition from Dockerfile
+ => [internal] load .dockerignore
+ => [internal] load metadata for node:20-alpine
+ => [1/7] FROM node:20-alpine@sha256:abc123...
+ => [2/7] WORKDIR /app
+ => [3/7] COPY package*.json ./
+ => [4/7] RUN npm ci --only=production
+ => [5/7] COPY . .
+ => [6/7] RUN npm run build
+ => [7/7] EXPOSE 3000
+ => exporting to image
+ => => naming to docker.io/library/myapp:latest
+
+Successfully built image myapp:latest`,
+    exitCode: 0,
+    durationMs: 45200,
+  },
+};
+
+const ansiColorsPreset: TerminalConfig = {
+  terminal: {
+    surfaceId: "terminal-preview-ansi",
+    command: "npm run lint",
+    stdout: `\x1b[32m✔\x1b[0m No ESLint warnings or errors
+\x1b[36minfo\x1b[0m Checking formatting...
+\x1b[33m⚠\x1b[0m 2 files need formatting
+  \x1b[90msrc/utils.ts\x1b[0m
+  \x1b[90msrc/api.ts\x1b[0m
+\x1b[32m✔\x1b[0m TypeScript compilation successful
+\x1b[1m\x1b[32mAll checks passed!\x1b[0m`,
+    exitCode: 0,
+    durationMs: 2341,
+  },
+};
+
+const collapsiblePreset: TerminalConfig = {
+  terminal: {
+    surfaceId: "terminal-preview-collapsible",
+    command: "npm install",
+    stdout:
+      Array.from({ length: 25 }, (_, i) => `added package-${i + 1}@1.0.0`).join(
+        "\n",
+      ) + "\n\nadded 25 packages in 3.2s",
+    exitCode: 0,
+    durationMs: 3200,
+    maxCollapsedLines: 8,
+  },
+};
+
+const noOutputPreset: TerminalConfig = {
+  terminal: {
+    surfaceId: "terminal-preview-no-output",
+    command: "touch newfile.txt",
+    exitCode: 0,
+    durationMs: 12,
+    cwd: "~/project",
+  },
+};
+
+export const terminalPresets: Record<TerminalPresetName, TerminalConfig> = {
+  success: successPreset,
+  error: errorPreset,
+  build: buildPreset,
+  ansiColors: ansiColorsPreset,
+  collapsible: collapsiblePreset,
+  noOutput: noOutputPreset,
+};
+
+export const terminalPresetDescriptions: Record<TerminalPresetName, string> = {
+  success: "Successful test run with duration",
+  error: "Failed build with TypeScript error",
+  build: "Docker build output",
+  ansiColors: "ANSI colored lint output",
+  collapsible: "Long output with collapse",
+  noOutput: "Command with no output",
+};

--- a/lib/workbench/component-registry.tsx
+++ b/lib/workbench/component-registry.tsx
@@ -9,13 +9,29 @@
 
 import type { ComponentType } from "react";
 import { MediaCard } from "@/components/tool-ui/media-card";
-import { OptionList, parseSerializableOptionList } from "@/components/tool-ui/option-list";
+import {
+  OptionList,
+  parseSerializableOptionList,
+} from "@/components/tool-ui/option-list";
+import {
+  CodeBlock,
+  parseSerializableCodeBlock,
+} from "@/components/tool-ui/code-block";
+import {
+  Terminal,
+  parseSerializableTerminal,
+} from "@/components/tool-ui/terminal";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type ComponentCategory = "cards" | "lists" | "forms" | "data";
+export type ComponentCategory =
+  | "cards"
+  | "lists"
+  | "forms"
+  | "data"
+  | "display";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyComponent = ComponentType<any>;
@@ -45,6 +61,18 @@ function OptionListWrapper(props: Record<string, unknown>) {
   return <OptionList {...parsed} />;
 }
 
+function CodeBlockWrapper(props: Record<string, unknown>) {
+  // Parse the serializable data into the expected format
+  const parsed = parseSerializableCodeBlock(props);
+  return <CodeBlock {...parsed} />;
+}
+
+function TerminalWrapper(props: Record<string, unknown>) {
+  // Parse the serializable data into the expected format
+  const parsed = parseSerializableTerminal(props);
+  return <Terminal {...parsed} />;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Registry
 // ─────────────────────────────────────────────────────────────────────────────
@@ -63,7 +91,8 @@ export const workbenchComponents: WorkbenchComponentEntry[] = [
       src: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop",
       alt: "Mountain sunrise with golden light",
       title: "Mountain Sunrise",
-      description: "A beautiful sunrise illuminates the mountain peaks with golden light.",
+      description:
+        "A beautiful sunrise illuminates the mountain peaks with golden light.",
       ratio: "16:9",
       domain: "unsplash.com",
       createdAtISO: new Date().toISOString(),
@@ -104,6 +133,40 @@ export const workbenchComponents: WorkbenchComponentEntry[] = [
         },
       ],
       selectionMode: "single",
+    },
+  },
+  {
+    id: "code-block",
+    label: "Code Block",
+    description:
+      "Syntax-highlighted code display with copy and collapse features",
+    category: "display",
+    component: CodeBlockWrapper,
+    defaultProps: {
+      surfaceId: "workbench-code-block",
+      code: `function greet(name: string) {
+  return \`Hello, \${name}!\`;
+}
+
+console.log(greet("World"));`,
+      language: "typescript",
+      filename: "greet.ts",
+      showLineNumbers: true,
+    },
+  },
+  {
+    id: "terminal",
+    label: "Terminal",
+    description: "Command output display with ANSI colors and exit codes",
+    category: "display",
+    component: TerminalWrapper,
+    defaultProps: {
+      surfaceId: "workbench-terminal",
+      command: "echo 'Hello, World!'",
+      stdout: "Hello, World!",
+      exitCode: 0,
+      durationMs: 45,
+      cwd: "~",
     },
   },
   // Placeholder entries for components not yet integrated

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -14,7 +14,11 @@ import { Files, File, Folder } from "fumadocs-ui/components/files";
 import * as React from "react";
 import { AutoLinkChildren, withAutoLink } from "@/lib/docs/auto-link";
 import { Mermaid } from "@/app/components/mdx/mermaid";
-import { OptionListPresetExample } from "@/app/docs/_components/preset-example";
+import {
+  OptionListPresetExample,
+  CodeBlockPresetExample,
+  TerminalPresetExample,
+} from "@/app/docs/_components/preset-example";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   // Wrap selected default components to auto-link Tool UI mentions
@@ -85,6 +89,8 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     AutoLinkChildren,
     Mermaid,
     OptionListPresetExample,
+    CodeBlockPresetExample,
+    TerminalPresetExample,
     ...components,
   };
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@upstash/redis": "^1.35.6",
     "ai": "^5.0.88",
     "ajv": "^8.17.1",
+    "ansi-to-react": "^6.1.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "freestyle-sandboxes": "^0.0.97",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      ansi-to-react:
+        specifier: ^6.1.6
+        version: 6.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3388,6 +3391,12 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  ansi-to-react@6.1.6:
+    resolution: {integrity: sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==}
+    peerDependencies:
+      react: ^16.3.2 || ^17.0.0
+      react-dom: ^16.3.2 || ^17.0.0
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -4339,6 +4348,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-carriage@1.3.1:
+    resolution: {integrity: sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -11620,6 +11632,13 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  ansi-to-react@6.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      anser: 1.4.10
+      escape-carriage: 1.3.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -12819,6 +12838,8 @@ snapshots:
       '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
+
+  escape-carriage@1.3.1: {}
 
   escape-html@1.0.3: {}
 


### PR DESCRIPTION
## What

Adds two new tool-ui components: **CodeBlock** and **Terminal**, following the established component patterns in the codebase.

## Why

These components provide rich display capabilities for code and terminal output in AI assistant UIs:
- **CodeBlock**: Display syntax-highlighted code with copy functionality
- **Terminal**: Display command execution results with ANSI color support

## How

### CodeBlock Component
- Syntax highlighting via Shiki with automatic light/dark theme support
- Copy button with visual feedback
- Line number display and line highlighting
- Collapsible mode for long code blocks
- Zod schema for prop validation

### Terminal Component  
- ANSI color parsing via `ansi-to-react`
- Exit code badge (green for success, red for failure)
- Duration display
- Separate copy buttons for command and output
- Collapsible mode for long output
- Zod schema for prop validation

### Supporting Changes
- Added 6 presets each for CodeBlock and Terminal demonstrating various use cases
- Documentation pages with MDX content
- Preview components integrated with preset selector
- Registry integration for docs and workbench
- Added `ansi-to-react` dependency

## Testing

- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] Manual UI testing via Playwright:
  - Syntax highlighting renders correctly
  - Copy buttons work with visual feedback
  - Line highlighting works
  - Collapsible mode expands/collapses
  - ANSI colors render (not raw escape codes)
  - Exit code badges show correct colors
  - Loading skeletons display with proper card containers
  - Light/dark theme switching works

## Files Changed

| Category | Files |
|----------|-------|
| CodeBlock component | `components/tool-ui/code-block/*` (6 files) |
| Terminal component | `components/tool-ui/terminal/*` (6 files) |
| Presets | `lib/presets/code-block.ts`, `lib/presets/terminal.ts` |
| Documentation | `app/docs/code-block/*`, `app/docs/terminal/*` |
| Previews | `app/docs/[component]/previews/*-preview.tsx` |
| Registry | `lib/docs/component-registry.ts`, `lib/workbench/component-registry.tsx` |
| Docs utilities | `app/docs/_components/*` |

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] Components use Zod schemas for prop validation
- [x] Loading states implemented with skeleton loaders
- [x] Light and dark theme support
- [x] Documentation pages added
- [x] Presets demonstrate key features