### PR TITLE
feat: add right-side table of contents navigation for docs pages

### DIFF
--- a/app/components/layout/page-shell.tsx
+++ b/app/components/layout/page-shell.tsx
@@ -3,11 +3,13 @@ import type { ReactNode } from "react";
 type ContentLayoutProps = {
   children: ReactNode;
   sidebar?: ReactNode;
+  rightSidebar?: ReactNode;
 };
 
 export default function ContentLayout({
   children,
   sidebar,
+  rightSidebar,
 }: ContentLayoutProps) {
   return (
     <div className="flex min-h-0 w-full max-w-[1440px] flex-1">
@@ -27,6 +29,21 @@ export default function ContentLayout({
         </div>
       ) : null}
       <div className="flex min-h-0 w-full flex-1 overflow-clip">{children}</div>
+      {rightSidebar ? (
+        <div className="relative hidden w-[220px] shrink-0 md:block">
+          <div
+            className="from-background pointer-events-none absolute top-0 right-2 left-0 z-10 h-12 bg-linear-to-b to-transparent"
+            aria-hidden="true"
+          />
+          <div className="h-full overflow-y-auto">
+            {rightSidebar}
+          </div>
+          <div
+            className="from-background pointer-events-none absolute right-2 bottom-0 left-0 z-10 h-12 bg-linear-to-t to-transparent"
+            aria-hidden="true"
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/app/docs/_components/component-docs-tabs.tsx
+++ b/app/docs/_components/component-docs-tabs.tsx
@@ -6,6 +6,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DocsBorderedShell } from "./docs-bordered-shell";
 import { DocsContent } from "./docs-content";
 import { useTabSearchParam } from "@/hooks/use-tab-search-param";
+import { useDocsToc } from "./docs-toc-context";
+import { DocsTocWrapper } from "./docs-toc-wrapper";
 
 type DocsTab = "docs" | "examples";
 
@@ -33,6 +35,7 @@ export const ComponentDocsTabs = memo(function ComponentDocsTabs({
   examples,
 }: ComponentDocsTabsProps) {
   const contentRef = useRef<HTMLDivElement>(null);
+  const { scrollContainerRef } = useDocsToc();
 
   const { activeTab, setActiveTab } = useTabSearchParam<DocsTab>({
     defaultTab: "docs",
@@ -85,13 +88,17 @@ export const ComponentDocsTabs = memo(function ComponentDocsTabs({
           className="relative flex min-h-0 flex-1 scroll-mt-16 flex-col"
         >
           <TabsContent
+            ref={scrollContainerRef}
             value="docs"
             className="scrollbar-subtle h-full min-h-0 flex-1 overflow-y-auto pt-12"
           >
-            <div className="z-0 min-h-0 flex-1 p-6 pb-24 sm:p-10 lg:p-12">
-              <DocsContent>
-                <Suspense fallback={<ContentSkeleton />}>{docs}</Suspense>
-              </DocsContent>
+            <div className="z-0 min-h-0 flex-1">
+              <div className="mx-auto flex max-w-[1200px] gap-8 p-6 pb-96 sm:p-10 sm:pb-96 lg:p-12 lg:pb-96">
+                <DocsContent>
+                  <Suspense fallback={<ContentSkeleton />}>{docs}</Suspense>
+                </DocsContent>
+                <DocsTocWrapper />
+              </div>
             </div>
           </TabsContent>
           <TabsContent

--- a/app/docs/_components/docs-article.tsx
+++ b/app/docs/_components/docs-article.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import type { ReactNode } from "react";
 import { DocsBorderedShell } from "./docs-bordered-shell";
 import { DocsContent } from "./docs-content";
+import { useDocsToc } from "./docs-toc-context";
+import { DocsTocWrapper } from "./docs-toc-wrapper";
 
 export function DocsArticle({
   children,
@@ -9,10 +13,18 @@ export function DocsArticle({
   children: ReactNode;
   className?: string;
 }) {
+  const { scrollContainerRef } = useDocsToc();
+
   return (
     <DocsBorderedShell>
-      <div className="scrollbar-subtle z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain p-6 pb-24 sm:p-10 lg:p-12 lg:pt-16">
-        <DocsContent className={className}>{children}</DocsContent>
+      <div
+        ref={scrollContainerRef}
+        className="scrollbar-subtle z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain"
+      >
+        <div className="mx-auto flex max-w-[1200px] gap-8 p-6 pb-96 sm:p-10 sm:pb-96 lg:p-12 lg:pb-96 lg:pt-16">
+          <DocsContent className={className}>{children}</DocsContent>
+          <DocsTocWrapper />
+        </div>
       </div>
     </DocsBorderedShell>
   );

--- a/app/docs/_components/docs-content.tsx
+++ b/app/docs/_components/docs-content.tsx
@@ -14,7 +14,7 @@ export function DocsContent({
   includePager = true,
 }: DocsContentProps) {
   return (
-    <div className={cn("prose dark:prose-invert mx-auto max-w-3xl", className)}>
+    <div className={cn("prose dark:prose-invert mx-auto max-w-3xl flex-1", className)}>
       {children}
       {includePager && <DocsPager />}
     </div>

--- a/app/docs/_components/docs-toc-context.tsx
+++ b/app/docs/_components/docs-toc-context.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+import { useExtractHeadings, type Heading } from "@/hooks/use-extract-headings";
+import { useHeadingsObserver } from "@/hooks/use-headings-observer";
+
+type DocsTocContextValue = {
+  scrollContainerRef: (node: HTMLElement | null) => void;
+  scrollContainer: HTMLElement | null;
+  headings: Heading[];
+  activeId: string | null;
+};
+
+const DocsTocContext = createContext<DocsTocContextValue | null>(null);
+
+export function useDocsToc() {
+  const context = useContext(DocsTocContext);
+  if (!context) {
+    throw new Error("useDocsToc must be used within DocsTocProvider");
+  }
+  return context;
+}
+
+export function DocsTocProvider({ children }: { children: ReactNode }) {
+  const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(
+    null,
+  );
+
+  const scrollContainerRef = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      setScrollContainer(node);
+    }
+  }, []);
+
+  const headings = useExtractHeadings(scrollContainer);
+  const activeId = useHeadingsObserver(headings, scrollContainer);
+
+  return (
+    <DocsTocContext.Provider
+      value={{
+        scrollContainerRef,
+        scrollContainer,
+        headings,
+        activeId,
+      }}
+    >
+      {children}
+    </DocsTocContext.Provider>
+  );
+}

--- a/app/docs/_components/docs-toc-mobile-toggle.tsx
+++ b/app/docs/_components/docs-toc-mobile-toggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { ListOrdered } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useDocsToc } from "./docs-toc-context";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+export function DocsTocMobileToggle({ onClick }: { onClick: () => void }) {
+  const { headings } = useDocsToc();
+  const isMobile = useIsMobile();
+
+  if (!isMobile || headings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Button
+      onClick={onClick}
+      size="icon"
+      variant="outline"
+      className="fixed bottom-6 right-6 z-50 h-12 w-12 rounded-full shadow-lg"
+      aria-label="Open table of contents"
+    >
+      <ListOrdered className="h-5 w-5" />
+    </Button>
+  );
+}

--- a/app/docs/_components/docs-toc-wrapper.tsx
+++ b/app/docs/_components/docs-toc-wrapper.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { DocsToc } from "./docs-toc";
+import { DocsTocMobileToggle } from "./docs-toc-mobile-toggle";
+
+export function DocsTocWrapper() {
+  const [tocOpen, setTocOpen] = useState(false);
+  const isMobile = useIsMobile();
+
+  return (
+    <>
+      {isMobile ? (
+        <>
+          <DocsTocMobileToggle onClick={() => setTocOpen(true)} />
+          <Sheet open={tocOpen} onOpenChange={setTocOpen}>
+            <SheetContent side="right" className="w-[280px] sm:w-[340px]">
+              <SheetHeader>
+                <SheetTitle>Table of Contents</SheetTitle>
+              </SheetHeader>
+              <div className="mt-4">
+                <DocsToc />
+              </div>
+            </SheetContent>
+          </Sheet>
+        </>
+      ) : (
+        <div className="hidden w-[200px] shrink-0 xl:block">
+          <div className="sticky top-6">
+            <DocsToc />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/docs/_components/docs-toc.tsx
+++ b/app/docs/_components/docs-toc.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
+import { cn } from "@/lib/ui/cn";
+import { useDocsToc } from "./docs-toc-context";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import { useTocKeyboardNav } from "@/hooks/use-toc-keyboard-nav";
+
+export function DocsToc() {
+  const { scrollContainer, headings, activeId } = useDocsToc();
+  const reducedMotion = useReducedMotion();
+  const linkRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const [indicatorTop, setIndicatorTop] = useState(0);
+
+  const scrollToHeading = useCallback(
+    (id: string) => {
+      const element = document.getElementById(id);
+      const container = scrollContainer;
+      if (!element || !container) return;
+
+      const stickyHeader = container.querySelector('[role="tablist"]');
+      const offset = stickyHeader
+        ? stickyHeader.getBoundingClientRect().height + 20
+        : 80;
+
+      const targetScroll = element.offsetTop - offset;
+
+      if (reducedMotion) {
+        container.scrollTop = targetScroll;
+      } else {
+        container.scrollTo({ top: targetScroll, behavior: "smooth" });
+      }
+    },
+    [scrollContainer, reducedMotion],
+  );
+
+  const { handleKeyDown, setLinkRef: setKeyboardLinkRef } = useTocKeyboardNav(
+    headings,
+    scrollToHeading,
+  );
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+    e.preventDefault();
+    scrollToHeading(id);
+  };
+
+  useEffect(() => {
+    if (typeof window === "undefined" || headings.length === 0) return;
+
+    const hash = window.location.hash.slice(1);
+    if (hash && headings.some((h) => h.id === hash)) {
+      setTimeout(() => scrollToHeading(hash), 200);
+    }
+  }, [headings, scrollToHeading]);
+
+  useEffect(() => {
+    linkRefs.current = linkRefs.current.slice(0, headings.length);
+  }, [headings]);
+
+  useEffect(() => {
+    const activeIndex = headings.findIndex((h) => h.id === activeId);
+    if (activeIndex >= 0 && linkRefs.current[activeIndex]) {
+      const activeLink = linkRefs.current[activeIndex];
+      if (activeLink) {
+        const linkRect = activeLink.getBoundingClientRect();
+        const navRect = activeLink.parentElement?.getBoundingClientRect();
+        if (navRect) {
+          const relativeTop = linkRect.top - navRect.top + linkRect.height / 2 - 6;
+          setIndicatorTop(relativeTop);
+        }
+      }
+    }
+  }, [activeId, headings]);
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  const activeIndex = headings.findIndex((h) => h.id === activeId);
+
+  const setLinkRef = (index: number) => (el: HTMLAnchorElement | null) => {
+    linkRefs.current[index] = el;
+    setKeyboardLinkRef(index)(el);
+  };
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className="relative space-y-1"
+      onKeyDown={handleKeyDown}
+    >
+      <p className="text-primary/60 mb-4 cursor-default text-xs tracking-widest uppercase select-none">
+        On This Page
+      </p>
+      {activeIndex >= 0 && (
+        <motion.span
+          aria-hidden="true"
+          className="bg-foreground pointer-events-none absolute -left-3 h-3 w-0.5 rounded-full"
+          initial={false}
+          animate={{
+            top: indicatorTop,
+            opacity: 1,
+          }}
+          transition={{
+            type: reducedMotion ? "tween" : "spring",
+            stiffness: 300,
+            damping: 30,
+            duration: reducedMotion ? 0 : undefined,
+          }}
+        />
+      )}
+      {headings.map((heading, index) => {
+        const isActive = heading.id === activeId;
+        return (
+          <a
+            key={heading.id}
+            ref={setLinkRef(index)}
+            href={`#${heading.id}`}
+            onClick={(e) => handleClick(e, heading.id)}
+            className={cn(
+              "relative block py-1 text-sm transition-colors",
+              "hover:text-foreground focus-visible:outline-none focus-visible:text-foreground",
+              isActive && "text-foreground font-medium",
+              !isActive && "text-muted-foreground",
+            )}
+            aria-current={isActive ? "true" : undefined}
+            title={heading.text}
+          >
+            <span className="line-clamp-2">{heading.text}</span>
+          </a>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -5,6 +5,8 @@ import ContentLayout from "@/app/components/layout/page-shell";
 import { HeaderFrame } from "@/app/components/layout/app-shell";
 import { ThemeToggle } from "@/app/components/builder/theme-toggle";
 import { DocsNav } from "./_components/docs-nav";
+import { DocsTocProvider } from "./_components/docs-toc-context";
+import { DocsTocWrapper } from "./_components/docs-toc-wrapper";
 
 export const metadata: Metadata = {
   title: {
@@ -18,7 +20,11 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
   return (
     <NuqsAdapter>
       <HeaderFrame rightContent={<ThemeToggle />}>
-        <ContentLayout sidebar={<DocsNav />}>{children}</ContentLayout>
+        <DocsTocProvider>
+          <ContentLayout sidebar={<DocsNav />}>
+            {children}
+          </ContentLayout>
+        </DocsTocProvider>
       </HeaderFrame>
     </NuqsAdapter>
   );

--- a/hooks/use-extract-headings.ts
+++ b/hooks/use-extract-headings.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+
+export type Heading = {
+  id: string;
+  text: string;
+};
+
+export function useExtractHeadings(
+  container: HTMLElement | null,
+): Heading[] {
+  const [headings, setHeadings] = useState<Heading[]>([]);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!container) return;
+
+    const timer = setTimeout(() => {
+      const h2ElementsWithId = container.querySelectorAll("h2[id]");
+      const extracted = Array.from(h2ElementsWithId).map((el) => ({
+        id: el.id,
+        text: el.textContent || "",
+      }));
+      setHeadings(extracted);
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [container, pathname]);
+
+  return headings;
+}

--- a/hooks/use-headings-observer.ts
+++ b/hooks/use-headings-observer.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Heading } from "./use-extract-headings";
+
+export function useHeadingsObserver(
+  headings: Heading[],
+  container: HTMLElement | null,
+): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!container || headings.length === 0) return;
+
+    let observer: IntersectionObserver | null = null;
+
+    const timeoutId = setTimeout(() => {
+      const headingElements = headings
+        .map((h) => document.getElementById(h.id))
+        .filter((el): el is HTMLElement => el !== null);
+
+      if (headingElements.length === 0) return;
+
+      observer = new IntersectionObserver(
+        (entries) => {
+          const intersecting = entries.filter((e) => e.isIntersecting);
+
+          if (intersecting.length > 0) {
+            const sorted = intersecting.sort(
+              (a, b) => a.boundingClientRect.top - b.boundingClientRect.top,
+            );
+            setActiveId(sorted[0].target.id);
+          }
+        },
+        {
+          root: container,
+          rootMargin: "-20% 0px -35% 0px",
+          threshold: [0, 0.5, 1],
+        },
+      );
+
+      headingElements.forEach((el) => observer!.observe(el));
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+  }, [headings, container]);
+
+  return activeId;
+}

--- a/hooks/use-toc-keyboard-nav.ts
+++ b/hooks/use-toc-keyboard-nav.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import type { Heading } from "./use-extract-headings";
+
+export function useTocKeyboardNav(
+  headings: Heading[],
+  onNavigate: (id: string) => void,
+) {
+  const [focusIndex, setFocusIndex] = useState(-1);
+  const linkRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  useEffect(() => {
+    linkRefs.current = linkRefs.current.slice(0, headings.length);
+  }, [headings]);
+
+  useEffect(() => {
+    if (focusIndex >= 0 && focusIndex < linkRefs.current.length) {
+      linkRefs.current[focusIndex]?.focus();
+    }
+  }, [focusIndex]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusIndex((prev) =>
+        prev < headings.length - 1 ? prev + 1 : prev,
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusIndex((prev) => (prev > 0 ? prev - 1 : prev));
+    } else if (e.key === "Enter" && focusIndex >= 0) {
+      e.preventDefault();
+      onNavigate(headings[focusIndex].id);
+    }
+  };
+
+  const setLinkRef = (index: number) => (el: HTMLAnchorElement | null) => {
+    linkRefs.current[index] = el;
+  };
+
+  return {
+    handleKeyDown,
+    setLinkRef,
+    focusIndex,
+  };
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -25,6 +25,22 @@ import {
 } from "@/app/docs/_components/preset-example";
 import { FeatureGrid, Feature } from "@/app/components/mdx/features";
 
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function createHeading(level: number) {
+  return function Heading({ children, ...props }: React.ComponentPropsWithoutRef<"h2">) {
+    const text = React.Children.toArray(children).join("");
+    const id = props.id || slugify(text);
+
+    return React.createElement(`h${level}`, { ...props, id }, children);
+  };
+}
+
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   // Wrap selected default components to auto-link Tool UI mentions
   const Base = defaultMdxComponents as MDXComponents;
@@ -44,6 +60,9 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
 
   return {
     ...defaultMdxComponents,
+
+    // Ensure headings have IDs for TOC
+    h2: createHeading(2),
 
     // Auto-link text mentions in common containers
     p: P,


### PR DESCRIPTION
## Summary

Adds a responsive table of contents navigation that appears on the right side of documentation pages (desktop xl+ breakpoint). The TOC automatically extracts H2 headings from MDX content and provides smooth scrolling navigation with an animated indicator pill showing the active section.

## Features

- **Automatic heading extraction**: Extracts H2 headings from rendered MDX content
- **Active section tracking**: Uses IntersectionObserver to highlight the current section as you scroll
- **Smooth scrolling**: Click any TOC link to smoothly scroll to that section with smart offset calculation
- **Animated indicator**: Spring-animated pill that moves to show the active section
- **Keyboard navigation**: Arrow keys to navigate, Enter to jump to section
- **Mobile responsive**: Collapses to a Sheet overlay with floating action button on mobile
- **Works everywhere**: Supports both DocsArticle and ComponentDocsTabs layouts

## Implementation

### New Components
- `docs-toc.tsx` - Main TOC navigation component with animated indicator
- `docs-toc-context.tsx` - React Context for sharing scroll container and state
- `docs-toc-wrapper.tsx` - Responsive wrapper (desktop sticky vs mobile sheet)
- `docs-toc-mobile-toggle.tsx` - Mobile floating action button

### New Hooks
- `use-extract-headings.ts` - Extracts H2 elements from DOM
- `use-headings-observer.ts` - IntersectionObserver for active section tracking
- `use-toc-keyboard-nav.ts` - Keyboard navigation handlers

### Changes
- Modified `mdx-components.tsx` to add slugify function for auto-generating heading IDs
- Updated `page-shell.tsx` to render right sidebar on xl+ breakpoints
- Integrated TOC context into docs layout
- Made docs components client-side to support TOC functionality

## Test Plan

- [x] TOC renders on desktop for pages with H2 headings
- [x] Active section highlights correctly as user scrolls
- [x] Clicking TOC links scrolls smoothly with correct offset
- [x] Keyboard navigation works (arrows + Enter)
- [x] Mobile toggle appears and Sheet opens correctly
- [x] Works in both ComponentDocsTabs and DocsArticle layouts
- [x] Indicator pill is properly aligned with text
- [x] Respects prefers-reduced-motion
- [x] Bottom padding ensures last section is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)