### PR TITLE
feat: add Question Flow component (renamed from Wizard Step)

### DIFF
--- a/app/docs/_components/preset-example.tsx
+++ b/app/docs/_components/preset-example.tsx
@@ -28,6 +28,11 @@ import {
   approvalCardPresets,
   ApprovalCardPresetName,
 } from "@/lib/presets/approval-card";
+import { QuestionFlow } from "@/components/tool-ui/question-flow";
+import {
+  questionFlowPresets,
+  QuestionFlowPresetName,
+} from "@/lib/presets/question-flow";
 
 function generateOptionListCode(preset: OptionListPresetName): string {
   const list = optionListPresets[preset].data;
@@ -404,6 +409,30 @@ export function ApprovalCardPresetExample({
       <Tab value="Preview">
         <div className="not-prose mx-auto max-w-sm">
           <ApprovalCard {...data} />
+        </div>
+      </Tab>
+      <Tab value="Code">
+        <DynamicCodeBlock lang="tsx" code={code} />
+      </Tab>
+    </Tabs>
+  );
+}
+
+interface QuestionFlowPresetExampleProps {
+  preset: QuestionFlowPresetName;
+}
+
+export function QuestionFlowPresetExample({
+  preset,
+}: QuestionFlowPresetExampleProps) {
+  const presetData = questionFlowPresets[preset];
+  const code = presetData.generateExampleCode(presetData.data);
+
+  return (
+    <Tabs items={["Preview", "Code"]}>
+      <Tab value="Preview">
+        <div className="not-prose mx-auto max-w-md">
+          <QuestionFlow {...presetData.data} />
         </div>
       </Tab>
       <Tab value="Code">

--- a/app/docs/question-flow/content.mdx
+++ b/app/docs/question-flow/content.mdx
@@ -1,0 +1,302 @@
+import { DocsHeader } from "../_components/docs-header";
+
+<DocsHeader
+  title="Question Flow"
+  description="Guide users through multi-step configuration flows."
+  mdxPath="app/docs/question-flow/content.mdx"
+/>
+
+<QuestionFlowPresetExample preset="progressive" />
+
+## Key Features
+
+<FeatureGrid>
+  <Feature icon="GitBranch" title="Progressive mode">
+    AI generates each step dynamically based on previous answers
+  </Feature>
+  <Feature icon="ListChecks" title="Upfront mode">
+    Define all steps upfront, component manages navigation internally
+  </Feature>
+  <Feature icon="CheckSquare" title="Single or multi-select">
+    Each step can allow one choice or multiple selections
+  </Feature>
+  <Feature icon="Receipt" title="Receipt state">
+    Display a summary of completed configuration choices
+  </Feature>
+</FeatureGrid>
+
+## Modes
+
+QuestionFlow supports two operational modes, determined by the props you pass:
+
+### Progressive Mode
+
+Pass `step`, `title`, and `options` to render a single step. The AI controls progression by generating new steps based on user selections.
+
+<QuestionFlowPresetExample preset="progressive" />
+
+### Upfront Mode
+
+Pass `steps` with all step definitions. The component manages internal state and navigation.
+
+<QuestionFlowPresetExample preset="upfront" />
+
+### Multi-Select Steps
+
+Set `selectionMode="multi"` to allow multiple selections per step.
+
+<QuestionFlowPresetExample preset="multi-select" />
+
+## Receipt State
+
+Pass `choice` with a title and summary to render a read-only confirmation of completed configuration.
+
+<QuestionFlowPresetExample preset="receipt" />
+
+## Source and Install
+
+Copy [`components/tool-ui/question-flow`](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/question-flow) and the [`shared`](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/shared) directory into your project. The `shared` folder contains utilities used by all Tool UI components. The `tool-ui` directory should sit alongside your shadcn `ui` directory.
+
+### Prerequisites
+
+This component requires the following [shadcn/ui](https://ui.shadcn.com) components:
+
+```bash
+pnpm dlx shadcn@latest add button separator
+```
+
+### Directory Structure
+
+<Files>
+  <Folder name="components" defaultOpen>
+    <Folder name="ui">
+      <File name="button.tsx" />
+      <File name="separator.tsx" />
+      <File name="..." />
+    </Folder>
+    <Folder name="tool-ui" defaultOpen>
+      <Folder name="shared" defaultOpen>
+        <File name="action-buttons.tsx" />
+        <File name="schema.ts" />
+        <File name="index.ts" />
+        <File name="..." />
+      </Folder>
+      <Folder name="question-flow" defaultOpen>
+        <File name="question-flow.tsx" />
+        <File name="schema.ts" />
+        <File name="index.tsx" />
+        <File name="..." />
+      </Folder>
+    </Folder>
+  </Folder>
+</Files>
+
+### Download
+
+- [**Shared Dependencies (GitHub)**](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/shared) ([ZIP](https://download-directory.github.io/?url=https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/shared))
+- [**Question Flow (GitHub)**](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/question-flow) ([ZIP](https://download-directory.github.io/?url=https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/question-flow))
+
+## Usage
+
+```tsx
+"use client";
+
+import { makeAssistantTool } from "@assistant-ui/react";
+import {
+  QuestionFlow,
+  QuestionFlowErrorBoundary,
+  parseSerializableQuestionFlow,
+  SerializableQuestionFlowSchema,
+  type SerializableQuestionFlow,
+} from "@/components/tool-ui/question-flow";
+
+export const ConfigureProjectTool = makeAssistantTool<
+  SerializableQuestionFlow,
+  Record<string, string[]>
+>({
+  toolName: "configureProject",
+  description: "Guide user through project configuration.",
+  parameters: SerializableQuestionFlowSchema,
+  render: ({ args, result, addResult, toolCallId }) => {
+    if (!args || typeof args !== "object") return null;
+
+    const questionFlow = parseSerializableQuestionFlow({
+      ...args,
+      id: (args as any)?.id ?? `wizard-${toolCallId}`,
+    });
+
+    return (
+      <QuestionFlowErrorBoundary>
+        {result !== undefined ? (
+          <QuestionFlow
+            id={questionFlow.id}
+            choice={{
+              title: "Project configured",
+              summary: Object.entries(result).map(([key, values]) => ({
+                label: key,
+                value: values.join(", "),
+              })),
+            }}
+          />
+        ) : (
+          <QuestionFlow
+            {...questionFlow}
+            onComplete={(answers) => addResult(answers)}
+          />
+        )}
+      </QuestionFlowErrorBoundary>
+    );
+  },
+});
+```
+
+Mount `<ConfigureProjectTool />` under `<AssistantRuntimeProvider>` to register the tool and its UI.
+
+## Progressive Mode Props
+
+<TypeTable
+  type={{
+    id: {
+      description: "Unique wizard identifier",
+      type: "string",
+      required: true,
+    },
+    step: {
+      description: "Current step number (1-indexed)",
+      type: "number",
+      required: true,
+    },
+    title: {
+      description: "Step title",
+      type: "string",
+      required: true,
+    },
+    description: {
+      description: "Optional step description",
+      type: "string",
+    },
+    options: {
+      description: "Available choices for this step",
+      type: "QuestionFlowOption[]",
+      required: true,
+    },
+    selectionMode: {
+      description: "Selection behavior for this step",
+      type: "'single' | 'multi'",
+      default: "'single'",
+    },
+    onSelect: {
+      description: "Called when user selects option(s) and clicks Next",
+      type: "(optionIds: string[]) => void | Promise<void>",
+    },
+    onBack: {
+      description: "Called when user clicks Back",
+      type: "() => void",
+    },
+  }}
+/>
+
+## Upfront Mode Props
+
+<TypeTable
+  type={{
+    id: {
+      description: "Unique wizard identifier",
+      type: "string",
+      required: true,
+    },
+    steps: {
+      description: "All step definitions",
+      type: "QuestionFlowDefinition[]",
+      required: true,
+    },
+    onComplete: {
+      description: "Called with all answers when wizard finishes",
+      type: "(answers: Record<string, string[]>) => void | Promise<void>",
+    },
+  }}
+/>
+
+## Receipt Mode Props
+
+<TypeTable
+  type={{
+    id: {
+      description: "Unique wizard identifier",
+      type: "string",
+      required: true,
+    },
+    choice: {
+      description: "Configuration summary to display",
+      type: "QuestionFlowChoice",
+      required: true,
+    },
+  }}
+/>
+
+## Option Schema
+
+<TypeTable
+  type={{
+    id: {
+      description: "Unique option identifier",
+      type: "string",
+      required: true,
+    },
+    label: {
+      description: "Display text",
+      type: "string",
+      required: true,
+    },
+    description: {
+      description: "Secondary text",
+      type: "string",
+    },
+    icon: {
+      description: "Optional icon element",
+      type: "ReactNode",
+    },
+    disabled: {
+      description: "Disable this option",
+      type: "boolean",
+    },
+  }}
+/>
+
+## Step Definition Schema
+
+<TypeTable
+  type={{
+    id: {
+      description: "Unique step identifier (used as answer key)",
+      type: "string",
+      required: true,
+    },
+    title: {
+      description: "Step title",
+      type: "string",
+      required: true,
+    },
+    description: {
+      description: "Optional step description",
+      type: "string",
+    },
+    options: {
+      description: "Available choices",
+      type: "QuestionFlowOption[]",
+      required: true,
+    },
+    selectionMode: {
+      description: "Selection behavior",
+      type: "'single' | 'multi'",
+      default: "'single'",
+    },
+  }}
+/>
+
+## Accessibility
+
+- Option buttons use keyboard-accessible controls
+- Focus management follows WAI-ARIA patterns for step navigation
+- Progress indicator provides context for screen readers
+- Back and Next buttons are keyboard-accessible

--- a/app/docs/question-flow/opengraph-image.tsx
+++ b/app/docs/question-flow/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import {
+  generateOgImage,
+  size as ogSize,
+  contentType as ogContentType,
+} from "@/lib/og/og-image";
+
+export const runtime = "nodejs";
+export const alt = "Tool UI - Wizard Step";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default async function Image() {
+  return generateOgImage("Wizard Step", "Multi-step configuration wizards with branching");
+}

--- a/app/docs/question-flow/page.tsx
+++ b/app/docs/question-flow/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import Content from "./content.mdx";
+import { ComponentDocsTabs } from "../_components/component-docs-tabs";
+import { ComponentPreview } from "../_components/component-preview";
+
+export const metadata: Metadata = {
+  title: "Question Flow",
+  description: "Multi-step guided questions with branching",
+};
+
+export const revalidate = 3600;
+
+export default function QuestionFlowDocsPage() {
+  return (
+    <ComponentDocsTabs
+      docs={<Content />}
+      examples={<ComponentPreview componentId="question-flow" />}
+    />
+  );
+}

--- a/components/tool-ui/question-flow/_adapter.tsx
+++ b/components/tool-ui/question-flow/_adapter.tsx
@@ -1,0 +1,14 @@
+/**
+ * Adapter: UI and utility re-exports for copy-standalone portability.
+ *
+ * When copying this component to another project, update these imports
+ * to match your project's paths:
+ *
+ *   cn        → Your Tailwind merge utility (e.g., "@/lib/utils", "~/lib/cn")
+ *   Button    → shadcn/ui Button
+ *   Separator → shadcn/ui Separator
+ */
+
+export { cn } from "../../../lib/ui/cn";
+export { Button } from "../../ui/button";
+export { Separator } from "../../ui/separator";

--- a/components/tool-ui/question-flow/error-boundary.tsx
+++ b/components/tool-ui/question-flow/error-boundary.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import {
+  ToolUIErrorBoundary,
+  type ToolUIErrorBoundaryProps,
+} from "../shared";
+
+export function QuestionFlowErrorBoundary(
+  props: Omit<ToolUIErrorBoundaryProps, "componentName">,
+) {
+  const { children, ...rest } = props;
+  return (
+    <ToolUIErrorBoundary componentName="QuestionFlow" {...rest}>
+      {children}
+    </ToolUIErrorBoundary>
+  );
+}

--- a/components/tool-ui/question-flow/index.tsx
+++ b/components/tool-ui/question-flow/index.tsx
@@ -1,0 +1,25 @@
+export { QuestionFlow, QuestionFlowProgress } from "./question-flow";
+export { QuestionFlowErrorBoundary } from "./error-boundary";
+export {
+  SerializableQuestionFlowSchema,
+  SerializableProgressiveModeSchema,
+  SerializableUpfrontModeSchema,
+  SerializableReceiptModeSchema,
+  QuestionFlowOptionSchema,
+  QuestionFlowStepDefinitionSchema,
+  QuestionFlowChoiceSchema,
+  QuestionFlowSummaryItemSchema,
+  parseSerializableQuestionFlow,
+  type SerializableQuestionFlow,
+  type SerializableProgressiveMode,
+  type SerializableUpfrontMode,
+  type SerializableReceiptMode,
+  type QuestionFlowProps,
+  type QuestionFlowProgressiveProps,
+  type QuestionFlowUpfrontProps,
+  type QuestionFlowReceiptProps,
+  type QuestionFlowOption,
+  type QuestionFlowStepDefinition,
+  type QuestionFlowChoice,
+  type QuestionFlowSummaryItem,
+} from "./schema";

--- a/components/tool-ui/question-flow/question-flow.tsx
+++ b/components/tool-ui/question-flow/question-flow.tsx
@@ -1,0 +1,803 @@
+"use client";
+
+import {
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  Fragment,
+} from "react";
+import type { KeyboardEvent } from "react";
+import type {
+  QuestionFlowProps,
+  QuestionFlowProgressiveProps,
+  QuestionFlowUpfrontProps,
+  QuestionFlowReceiptProps,
+  QuestionFlowOption,
+} from "./schema";
+import { cn, Button, Separator } from "./_adapter";
+import { Check, ChevronLeft } from "lucide-react";
+
+interface SelectionIndicatorProps {
+  mode: "single" | "multi";
+  isSelected: boolean;
+  disabled?: boolean;
+}
+
+interface ProgressBarProps {
+  current: number;
+  total: number;
+}
+
+function ProgressBar({ current, total }: ProgressBarProps) {
+  return (
+    <div
+      className="flex h-1.5 gap-1"
+      role="progressbar"
+      aria-valuenow={current}
+      aria-valuemin={1}
+      aria-valuemax={total}
+    >
+      {Array.from({ length: total }).map((_, i) => (
+        <div
+          key={i}
+          className="relative flex-1 overflow-hidden rounded-full bg-muted"
+        >
+          <div
+            className={cn(
+              "absolute inset-0 origin-left rounded-full bg-primary",
+              "motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out",
+              i < current ? "scale-x-100" : "scale-x-0",
+            )}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SelectionIndicator({
+  mode,
+  isSelected,
+  disabled,
+}: SelectionIndicatorProps) {
+  const shape = mode === "single" ? "rounded-full" : "rounded";
+
+  return (
+    <div
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center border-2",
+        "motion-safe:transition-colors motion-safe:duration-200",
+        shape,
+        isSelected && [
+          "border-primary bg-primary text-primary-foreground",
+          "motion-safe:animate-[spring-bounce_500ms_cubic-bezier(0.34,1.56,0.64,1)]",
+        ],
+        !isSelected && "border-muted-foreground/50",
+        disabled && "opacity-50",
+      )}
+    >
+      {mode === "multi" && isSelected && (
+        <Check
+          className="size-3 [&_path]:motion-safe:animate-[check-draw_400ms_cubic-bezier(0.34,1.56,0.64,1)_100ms_backwards]"
+          strokeWidth={3}
+          style={{ "--check-path-length": "24" } as React.CSSProperties}
+        />
+      )}
+      {mode === "single" && isSelected && (
+        <span className="size-2 rounded-full bg-current motion-safe:animate-[spring-bounce_500ms_cubic-bezier(0.34,1.56,0.64,1)]" />
+      )}
+    </div>
+  );
+}
+
+interface OptionItemProps {
+  option: QuestionFlowOption;
+  isSelected: boolean;
+  isDisabled: boolean;
+  selectionMode: "single" | "multi";
+  isFirst: boolean;
+  isLast: boolean;
+  onToggle: () => void;
+  tabIndex?: number;
+  onFocus?: () => void;
+  buttonRef?: (el: HTMLButtonElement | null) => void;
+}
+
+function OptionItem({
+  option,
+  isSelected,
+  isDisabled,
+  selectionMode,
+  isFirst,
+  isLast,
+  onToggle,
+  tabIndex,
+  onFocus,
+  buttonRef,
+}: OptionItemProps) {
+  const hasAdjacentOptions = !isFirst && !isLast;
+
+  return (
+    <Button
+      ref={buttonRef}
+      data-id={option.id}
+      variant="ghost"
+      size="lg"
+      role="option"
+      aria-selected={isSelected}
+      onClick={onToggle}
+      onFocus={onFocus}
+      tabIndex={tabIndex}
+      disabled={isDisabled}
+      className={cn(
+        "peer group relative h-auto min-h-[50px] w-full justify-start text-left text-sm font-medium",
+        "rounded-none border-0 bg-transparent px-0 py-2 text-base shadow-none transition-none hover:bg-transparent! @md/question-flow:text-sm",
+        isFirst && "pb-2.5",
+        hasAdjacentOptions && "py-2.5",
+      )}
+    >
+      <span
+        className={cn(
+          "bg-primary/5 absolute inset-0 -mx-3 -my-0.5 rounded-xl opacity-0 transition-opacity group-hover:opacity-100",
+        )}
+      />
+      <div className="relative flex items-start gap-3">
+        <span className="flex h-6 items-center">
+          <SelectionIndicator
+            mode={selectionMode}
+            isSelected={isSelected}
+            disabled={option.disabled}
+          />
+        </span>
+        {option.icon && (
+          <span className="flex h-6 items-center">{option.icon}</span>
+        )}
+        <div className="flex flex-col text-left">
+          <span className="leading-6 text-pretty">{option.label}</span>
+          {option.description && (
+            <span className="text-muted-foreground text-sm font-normal text-pretty">
+              {option.description}
+            </span>
+          )}
+        </div>
+      </div>
+    </Button>
+  );
+}
+
+function QuestionFlowSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "@container/question-flow flex w-full min-w-80 max-w-md flex-col",
+        className,
+      )}
+      data-slot="question-flow-skeleton"
+      aria-busy="true"
+    >
+      <div className="bg-card flex w-full flex-col gap-4 rounded-2xl border p-5 shadow-xs">
+        <div className="flex flex-col gap-2">
+          <div className="bg-muted h-4 w-16 rounded motion-safe:animate-pulse" />
+          <div className="bg-muted h-6 w-3/4 rounded motion-safe:animate-pulse" />
+          <div className="bg-muted h-4 w-full rounded motion-safe:animate-pulse" />
+        </div>
+        <div className="flex flex-col gap-3 pt-2">
+          <div className="flex items-center gap-3">
+            <div className="bg-muted size-4 rounded-full motion-safe:animate-pulse" />
+            <div className="bg-muted h-5 flex-1 rounded motion-safe:animate-pulse" />
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="bg-muted size-4 rounded-full motion-safe:animate-pulse" />
+            <div className="bg-muted h-5 flex-1 rounded motion-safe:animate-pulse" />
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="bg-muted size-4 rounded-full motion-safe:animate-pulse" />
+            <div className="bg-muted h-5 flex-1 rounded motion-safe:animate-pulse" />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <div className="bg-muted h-9 w-16 rounded-full motion-safe:animate-pulse" />
+          <div className="bg-muted h-9 w-20 rounded-full motion-safe:animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QuestionFlowReceipt({
+  id,
+  choice,
+  className,
+}: QuestionFlowReceiptProps) {
+  return (
+    <div
+      className={cn(
+        "@container/question-flow flex w-full min-w-80 max-w-md flex-col",
+        "text-foreground",
+        "motion-safe:animate-in motion-safe:fade-in motion-safe:blur-in-sm motion-safe:zoom-in-95 motion-safe:duration-300 motion-safe:ease-out motion-safe:fill-mode-both",
+        className,
+      )}
+      data-slot="question-flow"
+      data-tool-ui-id={id}
+      data-receipt="true"
+      role="status"
+      aria-label={choice.title}
+    >
+      <div
+        className={cn(
+          "bg-card/60 flex w-full flex-col gap-3 rounded-2xl border px-5 py-4 shadow-xs",
+        )}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-base font-medium">{choice.title}</span>
+          <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-500">
+            <Check className="size-3.5" />
+            Complete
+          </span>
+        </div>
+        <div className="flex flex-col">
+          {choice.summary.map((item, index) => (
+            <Fragment key={index}>
+              {index > 0 && <Separator className="my-2" />}
+              <div
+                className="flex flex-col gap-0.5 text-sm motion-safe:animate-in motion-safe:fade-in motion-safe:blur-in-sm motion-safe:slide-in-from-bottom-1 motion-safe:duration-300 motion-safe:ease-out motion-safe:fill-mode-both"
+                style={{ animationDelay: `${150 + index * 75}ms` }}
+              >
+                <span className="text-muted-foreground">{item.label}</span>
+                <span className="font-medium">{item.value}</span>
+              </div>
+            </Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface StepBodyData {
+  stepKey: string;
+  title: string;
+  description?: string;
+  options: QuestionFlowOption[];
+  selectionMode: "single" | "multi";
+  selectedIds: Set<string>;
+}
+
+interface StepContentProps {
+  step: number;
+  totalSteps?: number;
+  title: string;
+  description?: string;
+  options: QuestionFlowOption[];
+  selectionMode: "single" | "multi";
+  selectedIds: Set<string>;
+  onToggle: (optionId: string) => void;
+  onBack?: () => void;
+  onNext: () => void;
+  showBack: boolean;
+  isLastStep: boolean;
+  id: string;
+  className?: string;
+  stepKey?: string;
+  exitingStepData?: StepBodyData | null;
+  transitionDirection?: "forward" | "backward";
+}
+
+function StepBodyContent({
+  stepKey,
+  title,
+  description,
+  options,
+  selectionMode,
+  selectedIds,
+  onToggle,
+  id,
+  isExiting,
+  transitionDirection,
+}: {
+  stepKey: string;
+  title: string;
+  description?: string;
+  options: QuestionFlowOption[];
+  selectionMode: "single" | "multi";
+  selectedIds: Set<string>;
+  onToggle?: (optionId: string) => void;
+  id: string;
+  isExiting?: boolean;
+  transitionDirection?: "forward" | "backward";
+}) {
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const optionStates = useMemo(() => {
+    return options.map((option) => {
+      const isSelected = selectedIds.has(option.id);
+      const isDisabled = option.disabled ?? false;
+      return { option, isSelected, isDisabled };
+    });
+  }, [options, selectedIds]);
+
+  const [activeIndex, setActiveIndex] = useState(() => {
+    const firstSelected = optionStates.findIndex(
+      (s) => s.isSelected && !s.isDisabled,
+    );
+    if (firstSelected >= 0) return firstSelected;
+    const firstEnabled = optionStates.findIndex((s) => !s.isDisabled);
+    return firstEnabled >= 0 ? firstEnabled : 0;
+  });
+
+  const focusOptionAt = useCallback((index: number) => {
+    const el = optionRefs.current[index];
+    if (el) el.focus();
+    setActiveIndex(index);
+  }, []);
+
+  const findNextEnabledIndex = useCallback(
+    (start: number, direction: 1 | -1) => {
+      const len = optionStates.length;
+      if (len === 0) return 0;
+      for (let s = 1; s <= len; s++) {
+        const idx = (start + direction * s + len) % len;
+        if (!optionStates[idx].isDisabled) return idx;
+      }
+      return start;
+    },
+    [optionStates],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (optionStates.length === 0 || isExiting) return;
+
+      const key = e.key;
+
+      if (key === "ArrowDown") {
+        e.preventDefault();
+        focusOptionAt(findNextEnabledIndex(activeIndex, 1));
+        return;
+      }
+
+      if (key === "ArrowUp") {
+        e.preventDefault();
+        focusOptionAt(findNextEnabledIndex(activeIndex, -1));
+        return;
+      }
+
+      if (key === "Home") {
+        e.preventDefault();
+        const first = optionStates.findIndex((s) => !s.isDisabled);
+        focusOptionAt(first >= 0 ? first : 0);
+        return;
+      }
+
+      if (key === "End") {
+        e.preventDefault();
+        for (let i = optionStates.length - 1; i >= 0; i--) {
+          if (!optionStates[i].isDisabled) {
+            focusOptionAt(i);
+            return;
+          }
+        }
+        return;
+      }
+
+      if (key === "Enter" || key === " ") {
+        e.preventDefault();
+        const current = optionStates[activeIndex];
+        if (!current || current.isDisabled) return;
+        onToggle?.(current.option.id);
+        return;
+      }
+    },
+    [activeIndex, findNextEnabledIndex, focusOptionAt, isExiting, onToggle, optionStates],
+  );
+
+  const isTransitioning = transitionDirection !== undefined;
+
+  const enterClass = transitionDirection === "forward"
+    ? "motion-safe:slide-in-from-right-4"
+    : "motion-safe:slide-in-from-left-4";
+
+  const exitClass = transitionDirection === "forward"
+    ? "motion-safe:slide-out-to-left-4"
+    : "motion-safe:slide-out-to-right-4";
+
+  return (
+    <div
+      key={stepKey}
+      className={cn(
+        "flex flex-col gap-4",
+        isExiting && [
+          "absolute inset-0",
+          "motion-safe:animate-out motion-safe:fade-out motion-safe:blur-out-sm motion-safe:duration-250 motion-safe:ease-out motion-safe:fill-mode-forwards",
+          exitClass,
+        ],
+        !isExiting && isTransitioning && [
+          "motion-safe:animate-in motion-safe:fade-in motion-safe:blur-in-sm motion-safe:duration-250 motion-safe:ease-out motion-safe:fill-mode-both",
+          enterClass,
+        ],
+      )}
+      aria-hidden={isExiting}
+    >
+      <div className="flex flex-col gap-1">
+        <h2
+          id={`${id}-title`}
+          className="text-lg font-semibold leading-tight"
+        >
+          {title}
+        </h2>
+        {description && (
+          <p
+            id={`${id}-description`}
+            className="text-muted-foreground text-sm"
+          >
+            {description}
+          </p>
+        )}
+      </div>
+
+      <div
+        className="flex flex-col px-1"
+        role="listbox"
+        aria-multiselectable={selectionMode === "multi"}
+        onKeyDown={isExiting ? undefined : handleKeyDown}
+      >
+        {optionStates.map(({ option, isSelected, isDisabled }, index) => (
+          <Fragment key={option.id}>
+            {index > 0 && (
+              <Separator
+                className="transition-opacity [@media(hover:hover)]:[&:has(+_:hover)]:opacity-0 [@media(hover:hover)]:[.peer:hover+&]:opacity-0"
+                orientation="horizontal"
+              />
+            )}
+            <OptionItem
+              option={option}
+              isSelected={isSelected}
+              isDisabled={isExiting || isDisabled}
+              selectionMode={selectionMode}
+              isFirst={index === 0}
+              isLast={index === optionStates.length - 1}
+              tabIndex={isExiting ? -1 : index === activeIndex ? 0 : -1}
+              onFocus={() => !isExiting && setActiveIndex(index)}
+              buttonRef={(el) => {
+                optionRefs.current[index] = el;
+              }}
+              onToggle={() => !isExiting && onToggle?.(option.id)}
+            />
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StepContent({
+  step,
+  totalSteps,
+  title,
+  description,
+  options,
+  selectionMode,
+  selectedIds,
+  onToggle,
+  onBack,
+  onNext,
+  showBack,
+  isLastStep,
+  id,
+  className,
+  stepKey,
+  exitingStepData,
+  transitionDirection = "forward",
+}: StepContentProps) {
+  const isTransitioning = exitingStepData !== null && exitingStepData !== undefined;
+  const canProceed = selectedIds.size > 0;
+
+  const stepLabel = totalSteps
+    ? `Step ${step} of ${totalSteps}`
+    : `Step ${step}`;
+
+  return (
+    <div
+      className={cn(
+        "@container/question-flow flex w-full min-w-80 max-w-md flex-col gap-3",
+        "text-foreground",
+        className,
+      )}
+      data-slot="question-flow"
+      data-tool-ui-id={id}
+      role="form"
+      aria-labelledby={`${id}-title`}
+      aria-describedby={description ? `${id}-description` : undefined}
+    >
+      <div
+        className={cn(
+          "bg-card flex w-full flex-col gap-4 rounded-2xl border p-5 shadow-xs",
+        )}
+      >
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-2">
+            <span
+              className="text-muted-foreground text-xs font-medium uppercase tracking-wide"
+              aria-label={stepLabel}
+            >
+              {stepLabel}
+            </span>
+            {totalSteps && (
+              <ProgressBar current={step} total={totalSteps} />
+            )}
+          </div>
+        </div>
+
+        <div className="relative">
+          {exitingStepData && (
+            <StepBodyContent
+              key={exitingStepData.stepKey}
+              stepKey={exitingStepData.stepKey}
+              title={exitingStepData.title}
+              description={exitingStepData.description}
+              options={exitingStepData.options}
+              selectionMode={exitingStepData.selectionMode}
+              selectedIds={exitingStepData.selectedIds}
+              id={id}
+              isExiting
+              transitionDirection={transitionDirection}
+            />
+          )}
+          <StepBodyContent
+            key={stepKey || "current"}
+            stepKey={stepKey || "current"}
+            title={title}
+            description={description}
+            options={options}
+            selectionMode={selectionMode}
+            selectedIds={selectedIds}
+            onToggle={onToggle}
+            id={id}
+            isExiting={false}
+            transitionDirection={exitingStepData ? transitionDirection : undefined}
+          />
+        </div>
+
+        <div className="flex items-center justify-between pt-2">
+          {showBack ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onBack}
+              disabled={isTransitioning}
+              className="gap-1 text-muted-foreground"
+            >
+              <ChevronLeft className="size-4" />
+              Back
+            </Button>
+          ) : (
+            <div />
+          )}
+          <Button
+            variant="default"
+            size="sm"
+            onClick={onNext}
+            disabled={!canProceed || isTransitioning}
+          >
+            {isLastStep ? "Complete" : "Next"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QuestionFlowProgressive({
+  id,
+  step,
+  title,
+  description,
+  options,
+  selectionMode = "single",
+  onSelect,
+  onBack,
+  className,
+  isLoading,
+}: QuestionFlowProgressiveProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const handleToggle = useCallback(
+    (optionId: string) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (selectionMode === "single") {
+          if (next.has(optionId)) {
+            next.delete(optionId);
+          } else {
+            next.clear();
+            next.add(optionId);
+          }
+        } else {
+          if (next.has(optionId)) {
+            next.delete(optionId);
+          } else {
+            next.add(optionId);
+          }
+        }
+        return next;
+      });
+    },
+    [selectionMode],
+  );
+
+  const handleNext = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    const selection = Array.from(selectedIds);
+    onSelect?.(selection);
+  }, [onSelect, selectedIds]);
+
+  if (isLoading) {
+    return <QuestionFlowSkeleton className={className} />;
+  }
+
+  return (
+    <StepContent
+      id={id}
+      step={step}
+      title={title}
+      description={description}
+      options={options}
+      selectionMode={selectionMode}
+      selectedIds={selectedIds}
+      onToggle={handleToggle}
+      onBack={onBack}
+      onNext={handleNext}
+      showBack={step > 1 && onBack !== undefined}
+      isLastStep={false}
+      className={className}
+    />
+  );
+}
+
+function QuestionFlowUpfront({
+  id,
+  steps,
+  onStepChange,
+  onComplete,
+  className,
+  isLoading,
+}: QuestionFlowUpfrontProps) {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string[]>>({});
+  const [exitingStepData, setExitingStepData] = useState<StepBodyData | null>(null);
+  const [transitionDirection, setTransitionDirection] = useState<"forward" | "backward">("forward");
+
+  const currentStep = steps[currentStepIndex];
+  const isLastStep = currentStepIndex === steps.length - 1;
+  const totalSteps = steps.length;
+
+  useEffect(() => {
+    if (exitingStepData) {
+      const timer = setTimeout(() => setExitingStepData(null), 250);
+      return () => clearTimeout(timer);
+    }
+  }, [exitingStepData]);
+
+  const currentSelection = useMemo(() => {
+    const answer = answers[currentStep.id];
+    return new Set(answer ?? []);
+  }, [answers, currentStep.id]);
+
+  const handleToggle = useCallback(
+    (optionId: string) => {
+      const mode = currentStep.selectionMode ?? "single";
+      setAnswers((prev) => {
+        const current = prev[currentStep.id] ?? [];
+        let next: string[];
+
+        if (mode === "single") {
+          next = current.includes(optionId) ? [] : [optionId];
+        } else {
+          next = current.includes(optionId)
+            ? current.filter((id) => id !== optionId)
+            : [...current, optionId];
+        }
+
+        return { ...prev, [currentStep.id]: next };
+      });
+    },
+    [currentStep.id, currentStep.selectionMode],
+  );
+
+  const handleBack = useCallback(() => {
+    if (currentStepIndex > 0) {
+      const currentStepData = steps[currentStepIndex];
+      const stepOptions: QuestionFlowOption[] = currentStepData.options.map((opt) => ({
+        ...opt,
+        icon: undefined,
+      }));
+
+      setExitingStepData({
+        stepKey: currentStepData.id,
+        title: currentStepData.title,
+        description: currentStepData.description,
+        options: stepOptions,
+        selectionMode: currentStepData.selectionMode ?? "single",
+        selectedIds: new Set(answers[currentStepData.id] ?? []),
+      });
+      setTransitionDirection("backward");
+      const prevIndex = currentStepIndex - 1;
+      setCurrentStepIndex(prevIndex);
+      onStepChange?.(steps[prevIndex].id);
+    }
+  }, [answers, currentStepIndex, onStepChange, steps]);
+
+  const handleNext = useCallback(() => {
+    if (currentSelection.size === 0) return;
+
+    if (isLastStep) {
+      onComplete?.(answers);
+    } else {
+      const currentStepData = steps[currentStepIndex];
+      const stepOptions: QuestionFlowOption[] = currentStepData.options.map((opt) => ({
+        ...opt,
+        icon: undefined,
+      }));
+
+      setExitingStepData({
+        stepKey: currentStepData.id,
+        title: currentStepData.title,
+        description: currentStepData.description,
+        options: stepOptions,
+        selectionMode: currentStepData.selectionMode ?? "single",
+        selectedIds: new Set(answers[currentStepData.id] ?? []),
+      });
+      setTransitionDirection("forward");
+      const nextIndex = currentStepIndex + 1;
+      setCurrentStepIndex(nextIndex);
+      onStepChange?.(steps[nextIndex].id);
+    }
+  }, [answers, currentSelection.size, currentStepIndex, isLastStep, onComplete, onStepChange, steps]);
+
+  if (isLoading) {
+    return <QuestionFlowSkeleton className={className} />;
+  }
+
+  const stepOptions: QuestionFlowOption[] = currentStep.options.map((opt) => ({
+    ...opt,
+    icon: undefined,
+  }));
+
+  return (
+    <StepContent
+      id={id}
+      step={currentStepIndex + 1}
+      totalSteps={totalSteps}
+      title={currentStep.title}
+      description={currentStep.description}
+      options={stepOptions}
+      selectionMode={currentStep.selectionMode ?? "single"}
+      selectedIds={currentSelection}
+      onToggle={handleToggle}
+      onBack={handleBack}
+      onNext={handleNext}
+      showBack={currentStepIndex > 0}
+      isLastStep={isLastStep}
+      className={className}
+      stepKey={currentStep.id}
+      exitingStepData={exitingStepData}
+      transitionDirection={transitionDirection}
+    />
+  );
+}
+
+export function QuestionFlow(props: QuestionFlowProps) {
+  if ("choice" in props && props.choice !== undefined) {
+    return <QuestionFlowReceipt {...(props as QuestionFlowReceiptProps)} />;
+  }
+
+  if ("steps" in props && props.steps !== undefined) {
+    return <QuestionFlowUpfront {...(props as QuestionFlowUpfrontProps)} />;
+  }
+
+  return <QuestionFlowProgressive {...(props as QuestionFlowProgressiveProps)} />;
+}
+
+export { QuestionFlowSkeleton as QuestionFlowProgress };

--- a/components/tool-ui/question-flow/schema.ts
+++ b/components/tool-ui/question-flow/schema.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import type { ReactNode } from "react";
+import {
+  ToolUIIdSchema,
+  ToolUIRoleSchema,
+  parseWithSchema,
+} from "../shared";
+
+export const QuestionFlowOptionSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().optional(),
+  icon: z.custom<ReactNode>().optional(),
+  disabled: z.boolean().optional(),
+});
+
+export type QuestionFlowOption = z.infer<typeof QuestionFlowOptionSchema>;
+
+export const QuestionFlowStepDefinitionSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  options: z.array(QuestionFlowOptionSchema.omit({ icon: true })).min(1),
+  selectionMode: z.enum(["single", "multi"]).optional(),
+});
+
+export type QuestionFlowStepDefinition = z.infer<typeof QuestionFlowStepDefinitionSchema>;
+
+export const QuestionFlowSummaryItemSchema = z.object({
+  label: z.string().min(1),
+  value: z.string().min(1),
+});
+
+export type QuestionFlowSummaryItem = z.infer<typeof QuestionFlowSummaryItemSchema>;
+
+export const QuestionFlowChoiceSchema = z.object({
+  title: z.string().min(1),
+  summary: z.array(QuestionFlowSummaryItemSchema).min(1),
+});
+
+export type QuestionFlowChoice = z.infer<typeof QuestionFlowChoiceSchema>;
+
+const BaseSchema = z.object({
+  id: ToolUIIdSchema,
+  role: ToolUIRoleSchema.optional(),
+});
+
+export const SerializableProgressiveModeSchema = BaseSchema.extend({
+  step: z.number().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  options: z.array(QuestionFlowOptionSchema.omit({ icon: true })).min(1),
+  selectionMode: z.enum(["single", "multi"]).optional(),
+});
+
+export type SerializableProgressiveMode = z.infer<
+  typeof SerializableProgressiveModeSchema
+>;
+
+export const SerializableUpfrontModeSchema = BaseSchema.extend({
+  steps: z.array(QuestionFlowStepDefinitionSchema).min(1),
+});
+
+export type SerializableUpfrontMode = z.infer<
+  typeof SerializableUpfrontModeSchema
+>;
+
+export const SerializableReceiptModeSchema = BaseSchema.extend({
+  choice: QuestionFlowChoiceSchema,
+});
+
+export type SerializableReceiptMode = z.infer<
+  typeof SerializableReceiptModeSchema
+>;
+
+export const SerializableQuestionFlowSchema = z.union([
+  SerializableProgressiveModeSchema,
+  SerializableUpfrontModeSchema,
+  SerializableReceiptModeSchema,
+]);
+
+export type SerializableQuestionFlow = z.infer<
+  typeof SerializableQuestionFlowSchema
+>;
+
+export function parseSerializableQuestionFlow(
+  input: unknown,
+): SerializableQuestionFlow {
+  return parseWithSchema(SerializableQuestionFlowSchema, input, "QuestionFlow");
+}
+
+interface BaseRuntimeProps {
+  className?: string;
+  isLoading?: boolean;
+}
+
+export interface QuestionFlowProgressiveProps
+  extends BaseRuntimeProps,
+    Omit<SerializableProgressiveMode, "options"> {
+  options: QuestionFlowOption[];
+  onSelect?: (optionIds: string[]) => void | Promise<void>;
+  onBack?: () => void;
+  steps?: never;
+  choice?: never;
+}
+
+export interface QuestionFlowUpfrontProps
+  extends BaseRuntimeProps,
+    SerializableUpfrontMode {
+  onStepChange?: (stepId: string) => void;
+  onComplete?: (answers: Record<string, string[]>) => void | Promise<void>;
+  step?: never;
+  choice?: never;
+}
+
+export interface QuestionFlowReceiptProps
+  extends Omit<BaseRuntimeProps, "isLoading">,
+    SerializableReceiptMode {
+  step?: never;
+  steps?: never;
+}
+
+export type QuestionFlowProps =
+  | QuestionFlowProgressiveProps
+  | QuestionFlowUpfrontProps
+  | QuestionFlowReceiptProps;

--- a/docs/brainstorms/2026-01-22-wizard-step-brainstorm.md
+++ b/docs/brainstorms/2026-01-22-wizard-step-brainstorm.md
@@ -1,0 +1,156 @@
+# WizardStep Component Brainstorm
+
+**Date:** 2026-01-22
+**Status:** Ready for planning
+
+## What We're Building
+
+A component for AI-controlled configuration wizards where users make sequential choices that can branch based on previous answers.
+
+### Core Concept
+
+WizardStep presents one question at a time in a wizard flow. It supports two modes:
+
+1. **Progressive mode** — AI generates each step dynamically based on previous answers
+2. **Upfront mode** — All steps defined ahead of time, component manages navigation
+
+Both modes share the same visual design: clean, focused, one step at a time.
+
+### Key Characteristics
+
+- **AI controls the flow** in progressive mode
+- **Component manages navigation** in upfront mode (instant back/forward)
+- **Choices only** — each step is multiple-choice (like OptionList)
+- **Just current step visible** — previous context handled by AI, not cluttering UI
+- **Final configuration summary** as receipt state
+
+## Why This Approach
+
+### Gap Analysis
+
+Existing components don't cover this use case well:
+
+- **OptionList** — Single decision, no wizard context or step awareness
+- **Plan** — Shows all steps at once, status-focused, not for collecting input
+- **PreferencesPanel** — Flat settings, not sequential/branching
+
+Using multiple OptionList calls in sequence is visually noisy and lacks:
+- Step context/framing ("Step 2 of 4")
+- Progress awareness
+- Back/undo capability
+- Unified schema for the AI
+
+### Single Component, Two Modes
+
+The UI is nearly identical between modes—both show one step at a time. The difference is in how content is determined and who controls navigation:
+
+| Aspect | Progressive Mode | Upfront Mode |
+|--------|------------------|--------------|
+| Steps defined | One at a time by AI | All upfront |
+| Total steps | Unknown (`totalSteps` omitted) | Known (`totalSteps={5}`) |
+| Navigation | AI controls | Component manages |
+| Back button | Triggers `onBack` callback | Works instantly |
+| Branching | AI decides next step | Linear or predefined branches |
+
+## Key Decisions
+
+1. **Named `WizardStep`** — Clear metaphor, familiar pattern
+
+2. **Variant-based design** — One component with two modes, not separate components
+
+3. **Choices-only scope** — Each step is multiple-choice. Complex inputs (text, dates) are out of scope for v1.
+
+4. **Receipt state** — Shows final configuration summary with all collected answers
+
+5. **No visible history** — Previous steps not shown in UI. AI tracks context.
+
+## API Sketch
+
+### Progressive Mode (AI-controlled)
+
+```tsx
+<WizardStep
+  id="database-type"
+  step={2}
+  // totalSteps omitted = progressive mode
+  title="Select database type"
+  description="Choose the database that best fits your needs"
+  options={[
+    { id: "postgres", label: "PostgreSQL", description: "Open source, feature-rich" },
+    { id: "mysql", label: "MySQL", description: "Widely supported" },
+    { id: "sqlite", label: "SQLite", description: "Embedded, zero config" },
+  ]}
+  onSelect={(optionId) => { /* AI generates next step */ }}
+  onBack={() => { /* AI shows previous step */ }}
+/>
+```
+
+### Upfront Mode (Component-managed)
+
+```tsx
+<WizardStep
+  id="project-setup"
+  steps={[
+    {
+      id: "language",
+      title: "Pick a language",
+      options: [
+        { id: "python", label: "Python" },
+        { id: "typescript", label: "TypeScript" },
+      ],
+    },
+    {
+      id: "framework",
+      title: "Pick a framework",
+      options: [
+        { id: "fastapi", label: "FastAPI" },
+        { id: "django", label: "Django" },
+      ],
+    },
+    // ...more steps
+  ]}
+  onComplete={(answers) => {
+    // answers: { language: "python", framework: "fastapi", ... }
+  }}
+/>
+```
+
+### Receipt State
+
+```tsx
+<WizardStep
+  id="project-setup"
+  complete={{
+    title: "Configuration complete",
+    summary: [
+      { label: "Language", value: "Python" },
+      { label: "Framework", value: "FastAPI" },
+      { label: "Database", value: "PostgreSQL" },
+    ],
+  }}
+/>
+```
+
+## Open Questions
+
+1. **Branching in upfront mode** — Should steps support conditional `next` logic, or is that only for progressive mode?
+
+2. **Step validation** — Should options support disabling based on previous answers?
+
+3. **Skip logic** — Can steps be skipped? What happens to those answers?
+
+4. **Animation** — Transition between steps? Slide left/right?
+
+5. **Keyboard shortcuts** — Arrow keys to navigate options, Enter to select, Escape to go back?
+
+## Success Criteria
+
+- AI can define a multi-step wizard and receive structured configuration output
+- Users can navigate back without AI roundtrip (in upfront mode)
+- Visual design clearly communicates "you're in a wizard, step N of M"
+- Receipt state shows clear summary of all decisions made
+- Works well in AI assistant chat interfaces (not too wide, readable)
+
+## Next Steps
+
+Run `/workflows:plan` to design the implementation.

--- a/docs/brainstorms/2026-01-23-wizard-step-visual-polish-brainstorm.md
+++ b/docs/brainstorms/2026-01-23-wizard-step-visual-polish-brainstorm.md
@@ -1,0 +1,62 @@
+---
+date: 2026-01-23
+topic: wizard-step-visual-polish
+---
+
+# WizardStep Visual Polish
+
+## What We're Building
+
+A comprehensive visual refinement pass on the WizardStep component to match the polish level established by Stats Display and Progress Tracker. This includes entrance animations, selection feedback with spring physics, step transitions, and a segmented progress bar.
+
+## Why This Approach
+
+The WizardStep component is functionally complete but lacks the microinteractions and visual refinements that make recent components feel premium. By applying the same animation patterns (spring easing, staggered entrances, SVG path animations) we establish a consistent feel across the library while raising the quality bar.
+
+## Key Decisions
+
+### 1. Segmented Progress Bar
+Add a horizontal segmented progress bar below the step label. Segments fill with animation as the user advances. This provides clearer spatial orientation than "Step X of Y" text alone.
+
+### 2. Selection Indicator Animation (Layered)
+Combine multiple effects for rich feedback:
+- **Spring bounce** on the indicator container (matches Progress Tracker)
+- **Check-draw** SVG path animation for the checkmark
+- **Scale pulse** subtle scale-up on selection
+- **Fill sweep** color fills from center outward
+
+### 3. Step Transitions (Morph Shared Elements)
+In upfront mode, the progress bar and card frame remain stable while content morphs. Options crossfade with slight vertical offset. This grounds the user spatially while content changes.
+
+### 4. Entrance Animations
+- Quick cascade stagger (75ms between options)
+- Options slide up + fade in with spring easing `cubic-bezier(0.16,1,0.3,1)`
+- Header content animates first, then options, then footer buttons
+
+### 5. Hover/Focus States
+Replace current `bg-primary/5` hover with border highlight:
+- Thin border appears around hovered option
+- Glow ring (`box-shadow`) on keyboard focus for accessibility
+
+### 6. Receipt State
+Already has `fade-blur-in` - add staggered reveal for summary rows to match the polish.
+
+## Animation Specifications
+
+| Element | Animation | Duration | Easing |
+|---------|-----------|----------|--------|
+| Option entrance | fade + slide-up | 400ms | `cubic-bezier(0.16,1,0.3,1)` |
+| Option stagger | delay between items | 75ms | - |
+| Selection indicator | spring-bounce | 500ms | `cubic-bezier(0.34,1.56,0.64,1)` |
+| Check path draw | strokeDashoffset | 400ms | `cubic-bezier(0.34,1.56,0.64,1)` |
+| Progress segment fill | width + color | 300ms | `ease-out` |
+| Step content morph | opacity + translateY | 250ms | `ease-out` |
+
+## Open Questions
+
+- Should the progress bar have a subtle glow/pulse on the current segment?
+- Do we need reduced motion variants for all animations (`motion-safe:` prefix)?
+
+## Next Steps
+
+→ `/workflows:plan` for implementation details

--- a/docs/plans/2026-01-22-feat-wizard-step-component-plan.md
+++ b/docs/plans/2026-01-22-feat-wizard-step-component-plan.md
@@ -1,0 +1,519 @@
+---
+title: "feat: Add WizardStep Component"
+type: feat
+date: 2026-01-22
+---
+
+# WizardStep Component
+
+## Overview
+
+A component for AI-controlled configuration wizards where users make sequential choices. Supports two modes in a single component:
+
+1. **Progressive mode** — AI generates each step dynamically based on previous answers
+2. **Upfront mode** — All steps defined ahead of time, component manages navigation
+
+Both modes share the same visual design: clean, focused, one step at a time.
+
+## Problem Statement / Motivation
+
+Existing Tool UI components don't cover multi-step decision flows:
+
+- **OptionList** — Single decision, no wizard context or step awareness
+- **Plan** — Shows all steps at once, status-focused, not for collecting input
+- **PreferencesPanel** — Flat settings, not sequential/branching
+
+Using multiple OptionList calls in sequence is visually noisy and lacks:
+- Step context/framing ("Step 2 of 4")
+- Progress awareness
+- Back/undo capability
+- Unified schema for the AI
+
+## Proposed Solution
+
+A single `WizardStep` component with two modes controlled by props:
+
+### Progressive Mode (AI-controlled)
+
+```tsx
+<WizardStep
+  id="database-type"
+  step={2}
+  title="Select database type"
+  description="Choose the database that best fits your needs"
+  options={[
+    { id: "postgres", label: "PostgreSQL", description: "Open source, feature-rich" },
+    { id: "mysql", label: "MySQL", description: "Widely supported" },
+  ]}
+  onSelect={(optionId) => { /* AI generates next step */ }}
+  onBack={() => { /* AI shows previous step */ }}
+/>
+```
+
+### Upfront Mode (Component-managed)
+
+```tsx
+<WizardStep
+  id="project-setup"
+  steps={[
+    {
+      id: "language",
+      title: "Pick a language",
+      options: [
+        { id: "python", label: "Python" },
+        { id: "typescript", label: "TypeScript" },
+      ],
+    },
+    {
+      id: "framework",
+      title: "Pick a framework",
+      options: [
+        { id: "fastapi", label: "FastAPI" },
+        { id: "django", label: "Django" },
+      ],
+    },
+  ]}
+  onComplete={(answers) => {
+    // answers: { language: "python", framework: "fastapi" }
+  }}
+/>
+```
+
+### Receipt State
+
+```tsx
+<WizardStep
+  id="project-setup"
+  choice={{
+    title: "Configuration complete",
+    summary: [
+      { label: "Language", value: "Python" },
+      { label: "Framework", value: "FastAPI" },
+    ],
+  }}
+/>
+```
+
+## Technical Approach
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Component count | One unified component | Simpler API, discriminated union types handle mode switching |
+| Forward navigation (upfront) | Explicit Next button | Matches OptionList pattern, allows correction before proceeding |
+| Back behavior (progressive) | Clear subsequent answers | AI needs to re-generate based on new selection |
+| Back behavior (upfront) | Preserve all answers | Linear flow, no branching, answers remain valid |
+| Selection mode | Per-step configurable | Steps can be single or multi-select via `selectionMode` prop |
+| Progress display | Show "Step N of M" in upfront, "Step N" in progressive | Users need orientation |
+
+### File Structure
+
+```
+components/tool-ui/wizard-step/
+├── index.tsx           # Barrel exports
+├── wizard-step.tsx     # Main component (progressive + upfront modes)
+├── schema.ts           # Zod schemas + SerializableWizardStep type
+├── _adapter.tsx        # shadcn re-exports
+└── error-boundary.tsx  # Error boundary wrapper
+```
+
+### Schema Design
+
+**Note:** Uses structural discrimination (like OptionList) rather than explicit `mode` field. Mode is inferred from which props are present: `step` → progressive, `steps` → upfront, `choice` → receipt.
+
+```typescript
+// schema.ts
+
+// Shared option schema (reuse from OptionList pattern)
+const WizardOptionSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().optional(),
+  disabled: z.boolean().optional(),
+});
+
+// Step definition (for upfront mode)
+const WizardStepDefinitionSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  options: z.array(WizardOptionSchema).min(1),
+  selectionMode: z.enum(["single", "multi"]).optional(), // defaults to "single"
+});
+
+// Receipt summary item
+const WizardSummaryItemSchema = z.object({
+  label: z.string().min(1),
+  value: z.string().min(1),
+});
+
+// Receipt state
+const WizardChoiceSchema = z.object({
+  title: z.string().min(1),
+  summary: z.array(WizardSummaryItemSchema).min(1),
+});
+
+// Base props shared by all modes
+const BaseSchema = z.object({
+  id: ToolUIIdSchema,
+  role: ToolUIRoleSchema.optional(),
+});
+
+// Progressive mode props (single step, AI-controlled)
+const ProgressiveModeSchema = BaseSchema.extend({
+  step: z.number().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  options: z.array(WizardOptionSchema).min(1),
+  selectionMode: z.enum(["single", "multi"]).optional(),
+  // Mutually exclusive markers
+  steps: z.undefined().optional(),
+  choice: z.undefined().optional(),
+});
+
+// Upfront mode props (all steps defined, component manages)
+const UpfrontModeSchema = BaseSchema.extend({
+  steps: z.array(WizardStepDefinitionSchema).min(1),
+  // Mutually exclusive markers
+  step: z.undefined().optional(),
+  choice: z.undefined().optional(),
+});
+
+// Receipt mode props
+const ReceiptModeSchema = BaseSchema.extend({
+  choice: WizardChoiceSchema,
+  // Mutually exclusive markers
+  step: z.undefined().optional(),
+  steps: z.undefined().optional(),
+});
+
+// Combined schema using z.union (structural discrimination)
+const SerializableWizardStepSchema = z.union([
+  ProgressiveModeSchema,
+  UpfrontModeSchema,
+  ReceiptModeSchema,
+]);
+```
+
+**Why structural discrimination?**
+- Matches existing Tool UI patterns (OptionList uses `choice` presence, not a `mode` field)
+- Simpler for AI to generate (no extra `mode` field to remember)
+- TypeScript narrows types correctly via `"step" in props` checks
+
+### Props Interface
+
+**Note:** Answers are always stored/returned as `string[]` internally, even for single-select (normalized). This avoids type ambiguity for consumers.
+
+```typescript
+// Base props for runtime
+interface BaseRuntimeProps {
+  className?: string;
+  isLoading?: boolean;
+}
+
+// Progressive mode callbacks
+interface WizardStepProgressiveProps extends BaseRuntimeProps {
+  id: string;
+  step: number;
+  title: string;
+  description?: string;
+  options: WizardOption[];
+  selectionMode?: "single" | "multi";
+  onSelect?: (optionIds: string[]) => void | Promise<void>; // Always array
+  onBack?: () => void;
+  // Structural discrimination markers (TypeScript only)
+  steps?: never;
+  choice?: never;
+}
+
+// Upfront mode callbacks
+interface WizardStepUpfrontProps extends BaseRuntimeProps {
+  id: string;
+  steps: WizardStepDefinition[];
+  onStepChange?: (stepId: string) => void; // Just navigation event
+  onComplete?: (answers: Record<string, string[]>) => void | Promise<void>; // Always arrays
+  // Structural discrimination markers (TypeScript only)
+  step?: never;
+  choice?: never;
+}
+
+// Receipt mode
+interface WizardStepReceiptProps {
+  id: string;
+  choice: WizardChoice;
+  className?: string;
+  // Structural discrimination markers (TypeScript only)
+  step?: never;
+  steps?: never;
+}
+
+// Union type with structural discrimination
+type WizardStepProps =
+  | WizardStepProgressiveProps
+  | WizardStepUpfrontProps
+  | WizardStepReceiptProps;
+```
+
+**Key changes from review feedback:**
+1. `onSelect` always receives `string[]` (normalized) - single-select returns `["selected-id"]`
+2. `onComplete` answers are `Record<string, string[]>` - consistent type, no union
+3. `onStepChange` simplified to just navigation event (step ID only)
+4. Added `never` markers for TypeScript structural discrimination
+
+### Component Structure
+
+```tsx
+// wizard-step.tsx
+
+function WizardStep(props: WizardStepProps) {
+  // Mode detection
+  if ("choice" in props) {
+    return <WizardStepReceipt {...props} />;
+  }
+
+  if ("steps" in props) {
+    return <WizardStepUpfront {...props} />;
+  }
+
+  return <WizardStepProgressive {...props} />;
+}
+
+// Progressive mode: renders single step
+function WizardStepProgressive({ ... }: WizardStepProgressiveProps) {
+  // Internal selection state
+  // Option rendering (similar to OptionList)
+  // Back/Next action buttons
+}
+
+// Upfront mode: manages step navigation internally
+function WizardStepUpfront({ ... }: WizardStepUpfrontProps) {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+
+  // Step navigation with preserved answers
+  // Final step shows "Complete" instead of "Next"
+}
+
+// Receipt: read-only summary
+function WizardStepReceipt({ ... }: WizardStepReceiptProps) {
+  // Summary display with check icon
+}
+```
+
+### UI Layout
+
+```
+┌─────────────────────────────────────────┐
+│ Step 2 of 4                             │  <- Progress (upfront) or "Step 2" (progressive)
+├─────────────────────────────────────────┤
+│ Select database type                    │  <- Title
+│ Choose the database that best fits...   │  <- Description (optional)
+├─────────────────────────────────────────┤
+│ ○ PostgreSQL                            │  <- Options (radio/checkbox based on selectionMode)
+│   Open source, feature-rich             │
+│                                         │
+│ ○ MySQL                                 │
+│   Widely supported                      │
+│                                         │
+│ ○ SQLite                                │
+│   Embedded, zero config                 │
+├─────────────────────────────────────────┤
+│                        [Back] [Next]    │  <- Action buttons
+└─────────────────────────────────────────┘
+```
+
+### Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Arrow Up/Down | Move focus between options |
+| Space/Enter | Toggle/select focused option |
+| Escape | Cancel (if onCancel provided) |
+| Tab | Move to action buttons |
+
+### Accessibility
+
+- `role="form"` on outer container
+- `aria-labelledby` pointing to step title
+- `aria-describedby` pointing to step description
+- Step progress announced: `aria-label="Step 2 of 4"`
+- Focus moves to first option on step transition
+- Live region announces step changes
+
+### Animation
+
+- Step transitions: `motion-safe:animate-[fade-blur-in_300ms]`
+- Option selection: subtle highlight transition
+- Receipt entrance: same fade-blur pattern as other components
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] Progressive mode renders single step with title, description, options
+- [ ] Progressive mode calls `onSelect` with option ID(s) when user confirms
+- [ ] Progressive mode calls `onBack` when user clicks Back
+- [ ] Progressive mode hides Back button on step 1
+- [ ] Upfront mode renders steps array with internal navigation
+- [ ] Upfront mode shows progress indicator ("Step N of M")
+- [ ] Upfront mode preserves answers when navigating back
+- [ ] Upfront mode calls `onComplete` with all answers on final step confirm
+- [ ] Receipt state shows summary with title and key-value pairs
+- [ ] Single-select mode allows exactly one selection
+- [ ] Multi-select mode allows multiple selections
+- [ ] `isLoading` prop shows skeleton state
+
+### Non-Functional Requirements
+
+- [ ] Keyboard fully accessible (arrow keys, enter, escape)
+- [ ] Screen reader announces step progress
+- [ ] Animations respect `prefers-reduced-motion`
+- [ ] Component width follows Tool UI standards (`min-w-80 max-w-md`)
+
+### Quality Gates
+
+- [ ] Schema validates correctly with Zod
+- [ ] TypeScript discriminated union prevents invalid prop combinations
+- [ ] Unit tests for mode detection and navigation
+- [ ] Visual regression tests for all states
+- [ ] Lighthouse accessibility score 100
+
+## Implementation Phases
+
+### Phase 1: Foundation
+
+**Files:**
+- `components/tool-ui/wizard-step/schema.ts`
+- `components/tool-ui/wizard-step/_adapter.tsx`
+- `components/tool-ui/wizard-step/index.tsx`
+
+**Tasks:**
+- [ ] Create schema with discriminated union for modes
+- [ ] Define TypeScript types for all props
+- [ ] Create parseSerializableWizardStep function
+- [ ] Set up adapter with shadcn re-exports
+- [ ] Create barrel exports
+
+### Phase 2: Progressive Mode
+
+**Files:**
+- `components/tool-ui/wizard-step/wizard-step.tsx`
+
+**Tasks:**
+- [ ] Implement WizardStepProgressive component
+- [ ] Render step title, description, options
+- [ ] Implement single-select option interaction
+- [ ] Implement multi-select option interaction
+- [ ] Add Back/Next action buttons
+- [ ] Wire up onSelect, onBack, onCancel callbacks
+- [ ] Add keyboard navigation (arrows, enter, escape)
+- [ ] Add loading skeleton state
+
+### Phase 3: Upfront Mode
+
+**Files:**
+- `components/tool-ui/wizard-step/wizard-step.tsx`
+
+**Tasks:**
+- [ ] Implement WizardStepUpfront component
+- [ ] Add internal step navigation state
+- [ ] Add answers accumulation state
+- [ ] Implement Back navigation (preserves answers)
+- [ ] Implement Next navigation
+- [ ] Show "Complete" on final step
+- [ ] Wire up onStepChange, onComplete callbacks
+- [ ] Add step progress indicator ("Step N of M")
+
+### Phase 4: Receipt State
+
+**Files:**
+- `components/tool-ui/wizard-step/wizard-step.tsx`
+
+**Tasks:**
+- [ ] Implement WizardStepReceipt component
+- [ ] Render summary title with check icon
+- [ ] Render key-value summary items
+- [ ] Add fade-blur-in animation
+
+### Phase 5: Error Boundary & Polish
+
+**Files:**
+- `components/tool-ui/wizard-step/error-boundary.tsx`
+- `components/tool-ui/wizard-step/wizard-step.tsx`
+
+**Tasks:**
+- [ ] Create WizardStepErrorBoundary
+- [ ] Add ARIA labels and live regions
+- [ ] Ensure focus management on step transitions
+- [ ] Add motion-safe animations
+- [ ] Final accessibility audit
+
+### Phase 6: Documentation & Presets
+
+**Files:**
+- `lib/presets/wizard-step.ts`
+- `lib/docs/component-registry.ts`
+- `lib/docs/preview-config.tsx`
+- `app/docs/wizard-step/content.mdx`
+
+**Tasks:**
+- [ ] Create 4-5 presets (project setup, database selection, deployment config, etc.)
+- [ ] Add to component registry
+- [ ] Configure preview rendering
+- [ ] Write documentation page
+
+## Review Feedback & Decisions
+
+Plan reviewed by DHH, Kieran (TypeScript), and Simplicity reviewers. Key feedback addressed:
+
+| Concern | Decision |
+|---------|----------|
+| **DHH: Two modes is over-engineered** | Keeping both modes per user preference. Upfront mode serves use cases where AI provides complete wizard definition. |
+| **Kieran: Discriminated union incorrectly structured** | Fixed. Now uses structural discrimination (matching OptionList pattern) instead of explicit `mode` field. |
+| **Kieran: Answer type ambiguity (`string \| string[]`)** | Fixed. Normalized to always `string[]` internally and in callbacks. |
+| **Kieran: `onStepChange` signature too broad** | Fixed. Simplified to `(stepId: string) => void` - just navigation event. |
+| **Simplicity: Remove `totalSteps`** | Kept but made truly optional. Progressive mode can work without it. |
+| **Simplicity: Remove `defaultValue`** | Removed from plan. Add in v2 if needed. |
+| **Simplicity: Remove `onCancel`** | Removed from plan. Add in v2 if needed. |
+
+**Deferred to v2:**
+- `defaultValue` / `defaultAnswers` props
+- `onCancel` callback
+- Controlled navigation in upfront mode
+- Per-step validation (minSelections)
+
+## Dependencies & Prerequisites
+
+- Existing shared utilities: `ActionButtons`, `useActionButtons`, schema helpers
+- OptionList patterns for option rendering and keyboard navigation
+- No external dependencies beyond existing shadcn/ui stack
+
+## Risk Analysis & Mitigation
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| TypeScript discriminated union complexity | Medium | Medium | Start with simpler union, iterate |
+| Upfront mode state management edge cases | Medium | Medium | Write comprehensive tests for navigation |
+| Focus management between steps | Low | Medium | Follow OptionList patterns closely |
+| Schema validation edge cases | Low | Low | Extensive Zod schema tests |
+
+## References
+
+### Internal References
+
+- Component workflow guide: `.claude/docs/component-workflow.md`
+- OptionList implementation: `components/tool-ui/option-list/option-list.tsx`
+- ApprovalCard receipt pattern: `components/tool-ui/approval-card/approval-card.tsx:22-78`
+- Keyboard navigation: `components/tool-ui/option-list/option-list.tsx:465-527`
+- Shared action buttons: `components/tool-ui/shared/action-buttons.tsx`
+
+### Design Documents
+
+- Brainstorm: `docs/brainstorms/2026-01-22-wizard-step-brainstorm.md`
+
+### Related Patterns
+
+- ProgressTracker for step visualization
+- PreferencesPanel for form-like interactions
+- Plan for multi-item workflows

--- a/docs/plans/2026-01-23-feat-wizard-step-visual-polish-plan.md
+++ b/docs/plans/2026-01-23-feat-wizard-step-visual-polish-plan.md
@@ -1,0 +1,306 @@
+---
+title: "feat: WizardStep Visual Polish"
+type: feat
+date: 2026-01-23
+---
+
+# WizardStep Visual Polish
+
+## Overview
+
+Add comprehensive visual refinements to the WizardStep component to match the polish level of Stats Display and Progress Tracker. This includes entrance animations, layered selection feedback with spring physics, step transitions, and a segmented progress bar.
+
+## Problem Statement / Motivation
+
+The WizardStep component is functionally complete but lacks the microinteractions and visual refinements that make recent Tool UI components feel premium. Users notice the quality gap when components are used side-by-side. By applying established animation patterns (spring easing, staggered entrances, SVG path animations), we maintain library consistency while raising the quality bar.
+
+## Proposed Solution
+
+Apply five categories of visual polish:
+
+1. **Segmented Progress Bar** (Upfront mode only)
+2. **Layered Selection Animation** (spring bounce + check-draw + scale pulse + fill sweep)
+3. **Step Transitions** (morph shared elements in upfront mode)
+4. **Entrance Animations** (75ms stagger cascade)
+5. **Hover/Focus States** (border highlight + glow ring)
+
+## Technical Approach
+
+### File Changes
+
+All changes are within `components/tool-ui/wizard-step/wizard-step.tsx` plus keyframe additions to `app/styles/custom-utilities.css`.
+
+### Phase 1: Selection Indicator Animation
+
+Enhance `SelectionIndicator` component with layered animations.
+
+**Animation Choreography (concurrent with staggered starts):**
+- 0ms: Spring bounce + scale pulse + fill sweep begin
+- 100ms: Check-draw begins (multi-select only)
+- 500ms: All complete
+
+**Single-select (radio dot):**
+- Spring bounce on container (500ms, `cubic-bezier(0.34,1.56,0.64,1)`)
+- Scale pulse (0.95 → 1.05 → 1)
+- Fill sweep (radial gradient reveal from center)
+- No check-draw (dot, not checkmark)
+
+**Multi-select (checkbox):**
+- All of the above plus check-draw SVG animation (400ms, 100ms delayed)
+- Uses existing `--check-path-length: 24` CSS variable
+
+**Code location:** `SelectionIndicator` function (~lines 27-50)
+
+```tsx
+// New animation classes for SelectionIndicator
+function SelectionIndicator({ mode, isSelected, disabled }: SelectionIndicatorProps) {
+  const shape = mode === "single" ? "rounded-full" : "rounded";
+
+  return (
+    <div
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center border-2",
+        "motion-safe:transition-all motion-safe:duration-200",
+        shape,
+        isSelected && [
+          "border-primary bg-primary text-primary-foreground",
+          "motion-safe:animate-[spring-bounce_500ms_cubic-bezier(0.34,1.56,0.64,1)]",
+        ],
+        !isSelected && "border-muted-foreground/50",
+        disabled && "opacity-50",
+      )}
+    >
+      {mode === "multi" && isSelected && (
+        <Check
+          className="size-3 [&_path]:motion-safe:animate-[check-draw_400ms_cubic-bezier(0.34,1.56,0.64,1)_100ms_backwards]"
+          strokeWidth={3}
+          style={{ "--check-path-length": "24" } as React.CSSProperties}
+        />
+      )}
+      {mode === "single" && isSelected && (
+        <span className="size-2 rounded-full bg-current motion-safe:animate-[spring-bounce_500ms_cubic-bezier(0.34,1.56,0.64,1)]" />
+      )}
+    </div>
+  );
+}
+```
+
+### Phase 2: Entrance Animations
+
+Add staggered entrance animations to options with 75ms delay between items.
+
+**Animation:** fade + slide-up (400ms, `cubic-bezier(0.16,1,0.3,1)`)
+
+**Sequence:**
+1. Header (step label, title, description) - base delay 0ms
+2. Options - base delay 150ms + (index * 75ms) each
+3. Footer buttons - base delay 150ms + (optionCount * 75ms) + 100ms
+
+**Code location:** `StepContent` function, wrap option items and pass index for delay calculation
+
+```tsx
+// Option entrance animation
+<OptionItem
+  // ... existing props
+  style={{
+    animationDelay: `${150 + index * 75}ms`,
+  }}
+  className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-400 motion-safe:ease-[cubic-bezier(0.16,1,0.3,1)] motion-safe:fill-mode-both"
+/>
+```
+
+### Phase 3: Segmented Progress Bar
+
+Add horizontal segmented progress bar in **upfront mode only**. Progressive mode continues showing "Step N" text (total steps unknown).
+
+**Visual spec:**
+- Horizontal bar below step label
+- Segments: equal width, 4px gap between
+- Filled segments: `bg-primary`
+- Unfilled segments: `bg-muted`
+- Current segment: filled (no glow initially)
+- Animation: width fill over 300ms ease-out
+
+**Code location:** New `ProgressBar` component, rendered in `StepContent` when `totalSteps` is provided
+
+```tsx
+interface ProgressBarProps {
+  current: number;
+  total: number;
+}
+
+function ProgressBar({ current, total }: ProgressBarProps) {
+  return (
+    <div
+      className="flex gap-1 h-1.5"
+      role="progressbar"
+      aria-valuenow={current}
+      aria-valuemin={1}
+      aria-valuemax={total}
+    >
+      {Array.from({ length: total }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(
+            "flex-1 rounded-full motion-safe:transition-colors motion-safe:duration-300",
+            i < current ? "bg-primary" : "bg-muted",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+### Phase 4: Step Transitions (Upfront Mode)
+
+Implement "morph shared elements" pattern: progress bar and card frame remain stable, content crossfades.
+
+**Stable elements:** Card border, progress bar, Back/Next button container
+**Morphing elements:** Title, description, option list (crossfade with slight vertical offset)
+
+**Animation:** 250ms ease-out opacity + translateY
+
+**Implementation approach:**
+- Track `prevStepIndex` with useRef
+- Detect direction (forward/back) for animation direction
+- Use CSS animation classes triggered by step change
+- Key the content container by step ID to trigger remount animation
+
+```tsx
+// Step content transition wrapper
+<div
+  key={currentStep.id}
+  className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-250 motion-safe:ease-out"
+>
+  {/* Title, description, options */}
+</div>
+```
+
+**Button disable during transition:** Disable Back/Next buttons for 250ms during transition to prevent rapid navigation state issues.
+
+### Phase 5: Hover/Focus States
+
+Replace `bg-primary/5` hover with border highlight.
+
+**Hover:** Thin border appears around option row
+**Focus:** Glow ring (box-shadow) for keyboard accessibility
+
+```tsx
+// OptionItem hover/focus classes
+<Button
+  className={cn(
+    // ... existing classes
+    // Replace: "bg-primary/5 ... group-hover:opacity-100"
+    // With:
+    "hover:ring-1 hover:ring-border hover:ring-inset",
+    "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+  )}
+>
+```
+
+### Phase 6: Receipt State Enhancement
+
+Add staggered reveal to summary rows (matching option stagger).
+
+**Animation:** fade-up (existing keyframe), 75ms stagger
+
+```tsx
+// Receipt summary row stagger
+{choice.summary.map((item, index) => (
+  <div
+    key={index}
+    className="flex justify-between text-sm motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-300 motion-safe:fill-mode-both"
+    style={{ animationDelay: `${index * 75}ms` }}
+  >
+    {/* ... */}
+  </div>
+))}
+```
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x] Selection indicators animate with spring bounce when selected/deselected
+- [x] Multi-select checkmarks draw with stroke animation
+- [x] Options cascade in with 75ms stagger on initial render
+- [x] Upfront mode shows segmented progress bar that fills as user advances
+- [x] Step transitions in upfront mode crossfade content while card frame remains stable
+- [x] Options show border highlight on hover
+- [x] Options show glow ring on keyboard focus
+- [x] Receipt summary rows stagger in with 75ms delay
+
+### Non-Functional Requirements
+
+- [x] All animations use `motion-safe:` prefix for accessibility
+- [x] Animations respect `prefers-reduced-motion: reduce` (instant state changes)
+- [x] No animation blocks user interaction (decorative only)
+- [x] Button disable during 250ms step transition prevents state bugs
+
+### Quality Gates
+
+- [x] TypeScript compiles without errors (`pnpm typecheck`)
+- [x] ESLint passes (`pnpm lint:fix`)
+- [ ] Visual inspection in browser matches spec (requires manual verification)
+- [ ] Test with DevTools "Emulate CSS media feature" → `prefers-reduced-motion: reduce`
+
+## Edge Cases Addressed
+
+| Scenario | Behavior |
+|----------|----------|
+| Rapid option toggling | Animations layer naturally, no blocking |
+| Interaction during entrance | Allowed - selection animation plays immediately |
+| Back/Next during transition | Buttons disabled for 250ms transition duration |
+| Progressive mode (no total steps) | No segmented progress bar, keeps "Step N" text |
+| Disabled options | Participate in entrance stagger with muted opacity |
+| Single-select indicator | Spring bounce + scale, no check-draw (uses dot) |
+| Multi-select indicator | Full layered animation including check-draw |
+
+## Dependencies & Prerequisites
+
+- Existing keyframes in `custom-utilities.css`: `spring-bounce`, `check-draw`, `fade-blur-in`
+- Tailwind `animate-in` utilities from `tw-animate-css`
+- `motion-safe:` Tailwind variant (built-in)
+
+No new dependencies required.
+
+## Implementation Order
+
+1. **Phase 1: Selection Indicator** - Core interaction feedback
+2. **Phase 5: Hover/Focus** - Quick win, improves interaction before animations
+3. **Phase 2: Entrance Animations** - Visual polish on initial render
+4. **Phase 3: Progress Bar** - New UI element (upfront mode only)
+5. **Phase 4: Step Transitions** - Most complex, depends on progress bar
+6. **Phase 6: Receipt State** - Final polish
+
+## Testing Checklist
+
+- [ ] Progressive mode: entrance animations, selection feedback, no progress bar
+- [ ] Upfront mode: all features including progress bar and step transitions
+- [ ] Multi-select step: check-draw animation fires
+- [ ] Single-select step: dot animation (no check-draw)
+- [ ] Keyboard navigation: focus ring visible and accessible
+- [ ] Reduced motion: all animations disabled, instant state changes
+- [ ] Receipt state: summary rows stagger correctly
+- [ ] Rapid interactions: no animation state bugs
+
+## References
+
+### Internal
+
+- Brainstorm: `docs/brainstorms/2026-01-23-wizard-step-visual-polish-brainstorm.md`
+- Animation keyframes: `app/styles/custom-utilities.css:1-154`
+- Progress Tracker reference: `components/tool-ui/progress-tracker/progress-tracker.tsx`
+- Stats Display reference: `components/tool-ui/stats-display/stats-display.tsx`
+
+### Animation Specifications
+
+| Element | Animation | Duration | Easing | Delay |
+|---------|-----------|----------|--------|-------|
+| Selection indicator | spring-bounce | 500ms | `cubic-bezier(0.34,1.56,0.64,1)` | 0ms |
+| Check-draw (multi) | stroke-dashoffset | 400ms | `cubic-bezier(0.34,1.56,0.64,1)` | 100ms |
+| Option entrance | fade + slide-up | 400ms | `cubic-bezier(0.16,1,0.3,1)` | 150ms + (index × 75ms) |
+| Progress segment | bg-color | 300ms | ease-out | 0ms |
+| Step content morph | fade + translateY | 250ms | ease-out | 0ms |
+| Receipt row stagger | fade-up | 300ms | ease-out | index × 75ms |

--- a/lib/docs/component-registry.ts
+++ b/lib/docs/component-registry.ts
@@ -132,6 +132,12 @@ export const componentsRegistry: ComponentMeta[] = [
     description: "Show command-line output and logs",
     path: "/docs/terminal",
   },
+  {
+    id: "question-flow",
+    label: "Question Flow",
+    description: "Multi-step guided questions with branching",
+    path: "/docs/question-flow",
+  },
 ];
 
 export function getComponentById(id: string): ComponentMeta | undefined {

--- a/lib/presets/question-flow.ts
+++ b/lib/presets/question-flow.ts
@@ -1,0 +1,192 @@
+import type {
+  SerializableQuestionFlow,
+  SerializableProgressiveMode,
+  SerializableUpfrontMode,
+  SerializableReceiptMode,
+} from "@/components/tool-ui/question-flow";
+import type { PresetWithCodeGen } from "./types";
+
+export type QuestionFlowPresetName =
+  | "progressive"
+  | "upfront"
+  | "multi-select"
+  | "receipt";
+
+function generateProgressiveCode(data: SerializableProgressiveMode): string {
+  const props: string[] = [];
+
+  props.push(`  id="${data.id}"`);
+  props.push(`  step={${data.step}}`);
+  props.push(`  title="${data.title}"`);
+
+  if (data.description) {
+    props.push(`  description="${data.description}"`);
+  }
+
+  props.push(
+    `  options={${JSON.stringify(data.options, null, 4).replace(/\n/g, "\n  ")}}`,
+  );
+
+  if (data.selectionMode && data.selectionMode !== "single") {
+    props.push(`  selectionMode="${data.selectionMode}"`);
+  }
+
+  props.push(`  onSelect={(ids) => console.log("Selected:", ids)}`);
+  props.push(`  onBack={() => console.log("Go back")}`);
+
+  return `<QuestionFlow\n${props.join("\n")}\n/>`;
+}
+
+function generateUpfrontCode(data: SerializableUpfrontMode): string {
+  const props: string[] = [];
+
+  props.push(`  id="${data.id}"`);
+  props.push(
+    `  steps={${JSON.stringify(data.steps, null, 4).replace(/\n/g, "\n  ")}}`,
+  );
+  props.push(`  onComplete={(answers) => console.log("Complete:", answers)}`);
+
+  return `<QuestionFlow\n${props.join("\n")}\n/>`;
+}
+
+function generateReceiptCode(data: SerializableReceiptMode): string {
+  const props: string[] = [];
+
+  props.push(`  id="${data.id}"`);
+  props.push(
+    `  choice={${JSON.stringify(data.choice, null, 4).replace(/\n/g, "\n  ")}}`,
+  );
+
+  return `<QuestionFlow\n${props.join("\n")}\n/>`;
+}
+
+function generateQuestionFlowCode(data: SerializableQuestionFlow): string {
+  if ("choice" in data && data.choice) {
+    return generateReceiptCode(data as SerializableReceiptMode);
+  }
+  if ("steps" in data && data.steps) {
+    return generateUpfrontCode(data as SerializableUpfrontMode);
+  }
+  return generateProgressiveCode(data as SerializableProgressiveMode);
+}
+
+export const questionFlowPresets: Record<
+  QuestionFlowPresetName,
+  PresetWithCodeGen<SerializableQuestionFlow>
+> = {
+  progressive: {
+    description: "AI-controlled step with database selection",
+    data: {
+      id: "question-flow-database",
+      step: 2,
+      title: "Select database type",
+      description: "Choose the database that best fits your project requirements.",
+      options: [
+        {
+          id: "postgres",
+          label: "PostgreSQL",
+          description: "Open source, feature-rich, great for complex queries",
+        },
+        {
+          id: "mysql",
+          label: "MySQL",
+          description: "Widely supported, good for web applications",
+        },
+        {
+          id: "sqlite",
+          label: "SQLite",
+          description: "Embedded, zero configuration, perfect for prototypes",
+        },
+      ],
+    } satisfies SerializableProgressiveMode,
+    generateExampleCode: generateQuestionFlowCode,
+  },
+  upfront: {
+    description: "Complete wizard with all steps defined upfront",
+    data: {
+      id: "question-flow-project-setup",
+      steps: [
+        {
+          id: "language",
+          title: "Select a programming language",
+          description: "This determines which frameworks and tools are available.",
+          options: [
+            { id: "python", label: "Python" },
+            { id: "typescript", label: "TypeScript" },
+            { id: "go", label: "Go" },
+          ],
+        },
+        {
+          id: "framework",
+          title: "Choose a framework",
+          description: "Pick the framework you're most comfortable with.",
+          options: [
+            { id: "fastapi", label: "FastAPI" },
+            { id: "django", label: "Django" },
+            { id: "flask", label: "Flask" },
+          ],
+        },
+        {
+          id: "database",
+          title: "Select your database",
+          description: "Your data will be stored and queried from here.",
+          options: [
+            { id: "postgres", label: "PostgreSQL" },
+            { id: "mysql", label: "MySQL" },
+            { id: "mongodb", label: "MongoDB" },
+          ],
+        },
+      ],
+    } satisfies SerializableUpfrontMode,
+    generateExampleCode: generateQuestionFlowCode,
+  },
+  "multi-select": {
+    description: "Step with multiple selections allowed",
+    data: {
+      id: "question-flow-features",
+      step: 3,
+      title: "Select features to include",
+      description: "Choose all the features you want in your project.",
+      selectionMode: "multi",
+      options: [
+        {
+          id: "auth",
+          label: "Authentication",
+          description: "User login and registration",
+        },
+        {
+          id: "api",
+          label: "REST API",
+          description: "API endpoints for external access",
+        },
+        {
+          id: "admin",
+          label: "Admin Panel",
+          description: "Dashboard for managing content",
+        },
+        {
+          id: "analytics",
+          label: "Analytics",
+          description: "Track user behavior and metrics",
+        },
+      ],
+    } satisfies SerializableProgressiveMode,
+    generateExampleCode: generateQuestionFlowCode,
+  },
+  receipt: {
+    description: "Completed wizard showing configuration summary",
+    data: {
+      id: "question-flow-receipt",
+      choice: {
+        title: "Project configured",
+        summary: [
+          { label: "Language", value: "Python" },
+          { label: "Framework", value: "FastAPI" },
+          { label: "Database", value: "PostgreSQL" },
+          { label: "Features", value: "Auth, API, Admin" },
+        ],
+      },
+    } satisfies SerializableReceiptMode,
+    generateExampleCode: generateQuestionFlowCode,
+  },
+};

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -49,6 +49,11 @@ const ItemCarouselPresetExample = dynamic(() =>
     (m) => m.ItemCarouselPresetExample
   )
 );
+const QuestionFlowPresetExample = dynamic(() =>
+  import("@/app/docs/_components/preset-example").then(
+    (m) => m.QuestionFlowPresetExample
+  )
+);
 const FeatureGrid = dynamic(() =>
   import("@/app/components/mdx/features").then((m) => m.FeatureGrid)
 );
@@ -131,6 +136,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     TerminalPresetExample,
     PlanPresetExample,
     ItemCarouselPresetExample,
+    QuestionFlowPresetExample,
     FeatureGrid,
     Feature,
     ...components,


### PR DESCRIPTION
Add multi-step guided question component with:
- Progressive mode (AI generates steps dynamically)
- Upfront mode (all steps defined upfront)
- Single/multi-select per step
- Receipt state for completed flows
- Smooth crossfade transitions with blur effects
- Animated progress bar

Renamed from Wizard Step to Question Flow for clarity.