### PR TITLE
Split receipt components from interactive surfaces

### DIFF
--- a/app/docs/_components/preset-example.tsx
+++ b/app/docs/_components/preset-example.tsx
@@ -4,7 +4,10 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { Chart } from "@/components/tool-ui/chart";
 import { chartPresets, ChartPresetName } from "@/lib/presets/chart";
-import { OptionList } from "@/components/tool-ui/option-list";
+import {
+  OptionList,
+  OptionListReceipt,
+} from "@/components/tool-ui/option-list";
 import { CodeBlock } from "@/components/tool-ui/code-block";
 import { Terminal } from "@/components/tool-ui/terminal";
 import {
@@ -23,12 +26,19 @@ import {
   itemCarouselPresets,
   ItemCarouselPresetName,
 } from "@/lib/presets/item-carousel";
-import { ApprovalCard } from "@/components/tool-ui/approval-card";
+import {
+  ApprovalCard,
+  ApprovalCardReceipt,
+} from "@/components/tool-ui/approval-card";
 import {
   approvalCardPresets,
   ApprovalCardPresetName,
 } from "@/lib/presets/approval-card";
-import { QuestionFlow } from "@/components/tool-ui/question-flow";
+import {
+  QuestionFlowProgressive,
+  QuestionFlowUpfront,
+  QuestionFlowReceipt,
+} from "@/components/tool-ui/question-flow";
 import {
   questionFlowPresets,
   QuestionFlowPresetName,
@@ -54,15 +64,16 @@ function generateOptionListCode(preset: OptionListPresetName): string {
     props.push(`  maxSelections={${list.maxSelections}}`);
   }
 
-  if (list.choice) {
+  if ("choice" in list && list.choice !== undefined) {
     const choiceValue =
       typeof list.choice === "string"
         ? `"${list.choice}"`
         : JSON.stringify(list.choice);
     props.push(`  choice={${choiceValue}}`);
+    return `<OptionListReceipt\n${props.join("\n")}\n/>`;
   }
 
-  if (list.responseActions) {
+  if ("responseActions" in list && list.responseActions) {
     const hasActions = Array.isArray(list.responseActions)
       ? list.responseActions.length > 0
       : list.responseActions.items.length > 0;
@@ -74,9 +85,7 @@ function generateOptionListCode(preset: OptionListPresetName): string {
     }
   }
 
-  if (!list.choice) {
-    props.push(`  onConfirm={(selection) => console.log(selection)}`);
-  }
+  props.push(`  onConfirm={(selection) => console.log(selection)}`);
 
   return `<OptionList\n${props.join("\n")}\n/>`;
 }
@@ -156,7 +165,11 @@ export function OptionListPresetExample({
     <Tabs items={["Preview", "Code"]}>
       <Tab value="Preview">
         <div className="not-prose mx-auto max-w-md">
-          <OptionList {...data} />
+          {"choice" in data ? (
+            <OptionListReceipt {...data} />
+          ) : (
+            <OptionList {...data} />
+          )}
         </div>
       </Tab>
       <Tab value="Code">
@@ -387,8 +400,9 @@ function generateApprovalCardCode(preset: ApprovalCardPresetName): string {
     props.push(`  cancelLabel="${data.cancelLabel}"`);
   }
 
-  if (data.choice) {
+  if ("choice" in data && data.choice !== undefined) {
     props.push(`  choice="${data.choice}"`);
+    return `<ApprovalCardReceipt\n${props.join("\n")}\n/>`;
   }
 
   return `<ApprovalCard\n${props.join("\n")}\n/>`;
@@ -408,7 +422,11 @@ export function ApprovalCardPresetExample({
     <Tabs items={["Preview", "Code"]}>
       <Tab value="Preview">
         <div className="not-prose mx-auto max-w-sm">
-          <ApprovalCard {...data} />
+          {"choice" in data ? (
+            <ApprovalCardReceipt {...data} />
+          ) : (
+            <ApprovalCard {...data} />
+          )}
         </div>
       </Tab>
       <Tab value="Code">
@@ -432,7 +450,13 @@ export function QuestionFlowPresetExample({
     <Tabs items={["Preview", "Code"]}>
       <Tab value="Preview">
         <div className="not-prose mx-auto max-w-md">
-          <QuestionFlow {...presetData.data} />
+          {"choice" in presetData.data ? (
+            <QuestionFlowReceipt {...presetData.data} />
+          ) : "steps" in presetData.data ? (
+            <QuestionFlowUpfront {...presetData.data} />
+          ) : (
+            <QuestionFlowProgressive {...presetData.data} />
+          )}
         </div>
       </Tab>
       <Tab value="Code">

--- a/app/docs/approval-card/content.mdx
+++ b/app/docs/approval-card/content.mdx
@@ -1,5 +1,5 @@
 import { DocsHeader } from "../_components/docs-header";
-import { ApprovalCard } from "@/components/tool-ui/approval-card";
+import { ApprovalCard, ApprovalCardReceipt } from "@/components/tool-ui/approval-card";
 
 <DocsHeader
   title="Approval Card"
@@ -61,12 +61,12 @@ import { ApprovalCard } from "@/components/tool-ui/approval-card";
 
 ## Receipt State
 
-When `decision` is set, the component renders in a compact receipt state showing the approval decision. Use this to display the outcome in conversation history.
+Use `<ApprovalCardReceipt>` to render a compact receipt state showing the approval decision. This is ideal for displaying the outcome in conversation history.
 
 <Tabs items={["Approved", "Denied"]}>
   <Tab>
     <div className="not-prose mx-auto max-w-sm">
-      <ApprovalCard
+      <ApprovalCardReceipt
         id="receipt-approved-example"
         title="Deploy to Production"
         choice="approved"
@@ -76,7 +76,7 @@ When `decision` is set, the component renders in a compact receipt state showing
   </Tab>
   <Tab>
     <div className="not-prose mx-auto max-w-sm">
-      <ApprovalCard
+      <ApprovalCardReceipt
         id="receipt-denied-example"
         title="Delete Project"
         choice="denied"
@@ -181,6 +181,7 @@ pnpm dlx shadcn@latest add button
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
   ApprovalCard,
+  ApprovalCardReceipt,
   ApprovalCardErrorBoundary,
   parseSerializableApprovalCard,
   SerializableApprovalCardSchema,
@@ -206,7 +207,7 @@ export const ApprovalTool = makeAssistantTool<
     return (
       <ApprovalCardErrorBoundary>
         {result !== undefined ? (
-          <ApprovalCard {...approvalCard} choice={result} />
+          <ApprovalCardReceipt {...approvalCard} choice={result} />
         ) : (
           <ApprovalCard
             {...approvalCard}
@@ -266,10 +267,6 @@ Mount `<ApprovalTool />` under `<AssistantRuntimeProvider>` to register the tool
     isLoading: {
       description: "Disables both buttons while an external operation is in progress",
       type: "boolean",
-    },
-    decision: {
-      description: "The finalized decision (renders receipt state when set)",
-      type: "'approved' | 'denied'",
     },
     onConfirm: {
       description: "Handler when user approves",

--- a/app/docs/gallery/page.tsx
+++ b/app/docs/gallery/page.tsx
@@ -10,6 +10,9 @@ import { StatsDisplay } from "@/components/tool-ui/stats-display";
 const ApprovalCard = dynamic(() =>
   import("@/components/tool-ui/approval-card").then((m) => m.ApprovalCard)
 );
+const ApprovalCardReceipt = dynamic(() =>
+  import("@/components/tool-ui/approval-card").then((m) => m.ApprovalCardReceipt)
+);
 const CitationList = dynamic(() =>
   import("@/components/tool-ui/citation").then((m) => m.CitationList)
 );
@@ -31,8 +34,14 @@ const LinkedInPost = dynamic(() =>
 const OptionList = dynamic(() =>
   import("@/components/tool-ui/option-list").then((m) => m.OptionList)
 );
+const OptionListReceipt = dynamic(() =>
+  import("@/components/tool-ui/option-list").then((m) => m.OptionListReceipt)
+);
 const OrderSummary = dynamic(() =>
   import("@/components/tool-ui/order-summary").then((m) => m.OrderSummary)
+);
+const OrderSummaryReceipt = dynamic(() =>
+  import("@/components/tool-ui/order-summary").then((m) => m.OrderSummaryReceipt)
 );
 const Plan = dynamic(() =>
   import("@/components/tool-ui/plan").then((m) => m.Plan)
@@ -52,8 +61,20 @@ const PreferencesPanel = dynamic(() =>
 const ProgressTracker = dynamic(() =>
   import("@/components/tool-ui/progress-tracker").then((m) => m.ProgressTracker)
 );
-const QuestionFlow = dynamic(() =>
-  import("@/components/tool-ui/question-flow").then((m) => m.QuestionFlow)
+const QuestionFlowProgressive = dynamic(() =>
+  import("@/components/tool-ui/question-flow").then(
+    (m) => m.QuestionFlowProgressive,
+  )
+);
+const QuestionFlowUpfront = dynamic(() =>
+  import("@/components/tool-ui/question-flow").then(
+    (m) => m.QuestionFlowUpfront,
+  )
+);
+const QuestionFlowReceipt = dynamic(() =>
+  import("@/components/tool-ui/question-flow").then(
+    (m) => m.QuestionFlowReceipt,
+  )
 );
 const MessageDraft = dynamic(() =>
   import("@/components/tool-ui/message-draft").then((m) => m.MessageDraft)
@@ -147,11 +168,23 @@ export default function ComponentsGalleryPage() {
           </div>
 
           <div className="mb-5 flex break-inside-avoid justify-center 2xl:mb-5">
-            <OptionList {...optionListPresets["max-selections"].data} />
+            {"choice" in optionListPresets["max-selections"].data ? (
+              <OptionListReceipt
+                {...optionListPresets["max-selections"].data}
+              />
+            ) : (
+              <OptionList {...optionListPresets["max-selections"].data} />
+            )}
           </div>
 
           <div className="mb-5 flex break-inside-avoid justify-center 2xl:mb-5">
-            <ApprovalCard {...approvalCardPresets["with-metadata"].data} />
+            {"choice" in approvalCardPresets["with-metadata"].data ? (
+              <ApprovalCardReceipt
+                {...approvalCardPresets["with-metadata"].data}
+              />
+            ) : (
+              <ApprovalCard {...approvalCardPresets["with-metadata"].data} />
+            )}
           </div>
 
           <div className="mb-5 flex break-inside-avoid justify-center 2xl:mb-5">
@@ -159,10 +192,17 @@ export default function ComponentsGalleryPage() {
           </div>
 
           <div className="mb-5 break-inside-avoid 2xl:mb-5">
-            <OrderSummary
-              {...orderSummaryPresets.default.data}
-              className="max-w-none"
-            />
+            {"choice" in orderSummaryPresets.default.data ? (
+              <OrderSummaryReceipt
+                {...orderSummaryPresets.default.data}
+                className="max-w-none"
+              />
+            ) : (
+              <OrderSummary
+                {...orderSummaryPresets.default.data}
+                className="max-w-none"
+              />
+            )}
           </div>
 
           <div className="mb-5 flex break-inside-avoid justify-center 2xl:mb-5">
@@ -174,11 +214,21 @@ export default function ComponentsGalleryPage() {
           </div>
 
           <div className="mb-5 flex break-inside-avoid justify-center 2xl:mb-5">
-            <QuestionFlow {...questionFlowPresets.upfront.data} />
+            {"choice" in questionFlowPresets.upfront.data ? (
+              <QuestionFlowReceipt {...questionFlowPresets.upfront.data} />
+            ) : "steps" in questionFlowPresets.upfront.data ? (
+              <QuestionFlowUpfront {...questionFlowPresets.upfront.data} />
+            ) : (
+              <QuestionFlowProgressive {...questionFlowPresets.upfront.data} />
+            )}
           </div>
 
           <div className="mb-5 flex break-inside-avoid justify-center 2xl:mb-5">
-            <OptionList {...optionListPresets.travel.data} />
+            {"choice" in optionListPresets.travel.data ? (
+              <OptionListReceipt {...optionListPresets.travel.data} />
+            ) : (
+              <OptionList {...optionListPresets.travel.data} />
+            )}
           </div>
 
           <div className="mb-5 flex break-inside-avoid justify-center 2xl:mb-5">

--- a/app/docs/option-list/content.mdx
+++ b/app/docs/option-list/content.mdx
@@ -27,7 +27,7 @@ import { DocsHeader } from "../_components/docs-header";
 
 ## Receipt State
 
-When `confirmed` is set, the component renders in a read-only receipt state showing only the confirmed selection(s). Use this to display past decisions in conversation history.
+Use `<OptionListReceipt>` to render a read-only receipt state showing only the confirmed selection(s). This is ideal for displaying past decisions in conversation history.
 
 <OptionListPresetExample preset="receipt" />
 
@@ -91,6 +91,7 @@ pnpm dlx shadcn@latest add button separator
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
   OptionList,
+  OptionListReceipt,
   OptionListErrorBoundary,
   parseSerializableOptionList,
   SerializableOptionListSchema,
@@ -118,7 +119,7 @@ export const SelectFormatTool = makeAssistantTool<
     return (
       <OptionListErrorBoundary>
         {result !== undefined ? (
-          <OptionList {...optionList} value={undefined} choice={result} />
+          <OptionListReceipt {...optionList} choice={result} />
         ) : (
           <OptionList
             {...optionList}
@@ -158,10 +159,7 @@ Mount `<SelectFormatTool />` under `<AssistantRuntimeProvider>` to register the 
       description: "Initial selection (uncontrolled)",
       type: "string | string[] | null",
     },
-    confirmed: {
-      description: "Confirmed selection (renders receipt state)",
-      type: "string | string[] | null",
-    },
+    // Receipt rendering uses <OptionListReceipt> with a required `choice`.
     minSelections: {
       description: "Minimum required selections",
       type: "number",

--- a/app/docs/order-summary/content.mdx
+++ b/app/docs/order-summary/content.mdx
@@ -1,5 +1,5 @@
 import { DocsHeader } from "../_components/docs-header";
-import { OrderSummary } from "@/components/tool-ui/order-summary";
+import { OrderSummary, OrderSummaryReceipt } from "@/components/tool-ui/order-summary";
 
 <DocsHeader
   title="Order Summary"
@@ -100,12 +100,12 @@ import { OrderSummary } from "@/components/tool-ui/order-summary";
 
 ## Receipt State
 
-When `decision` is set, the component renders in a dimmed receipt state showing the confirmed order with order ID and timestamp.
+Use `<OrderSummaryReceipt>` to render a dimmed receipt state showing the confirmed order with order ID and timestamp.
 
 <Tabs items={["Preview", "Code"]}>
   <Tab>
     <div className="not-prose mx-auto max-w-md">
-      <OrderSummary
+      <OrderSummaryReceipt
         id="receipt-example"
         title="Order Confirmed"
         items={[
@@ -134,12 +134,12 @@ When `decision` is set, the component renders in a dimmed receipt state showing 
   </Tab>
   <Tab>
     ```tsx
-    <OrderSummary
+    <OrderSummaryReceipt
       id="receipt-example"
       title="Order Confirmed"
       items={[...]}
       pricing={{...}}
-      decision={{
+      choice={{
         action: "confirm",
         orderId: "ORD-2024-8847",
         confirmedAt: "2024-12-15T14:32:00Z",
@@ -254,6 +254,7 @@ pnpm dlx shadcn@latest add button separator skeleton
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
   OrderSummary,
+  OrderSummaryReceipt,
   OrderSummaryErrorBoundary,
   parseSerializableOrderSummary,
   SerializableOrderSummarySchema,
@@ -279,7 +280,7 @@ export const OrderSummaryTool = makeAssistantTool<
     return (
       <OrderSummaryErrorBoundary>
         {result !== undefined ? (
-          <OrderSummary {...data} choice={result} />
+          <OrderSummaryReceipt {...data} choice={result} />
         ) : (
           <OrderSummary
             {...data}
@@ -325,10 +326,6 @@ Mount `<OrderSummaryTool />` under `<AssistantRuntimeProvider>` to register the 
       description: "Pricing breakdown for the order",
       type: "Pricing",
       required: true,
-    },
-    decision: {
-      description: "When set, renders the receipt state",
-      type: "OrderDecision",
     },
     className: {
       description: "Additional CSS classes",

--- a/app/docs/progress-tracker/content.mdx
+++ b/app/docs/progress-tracker/content.mdx
@@ -1,5 +1,5 @@
 import { DocsHeader } from "../_components/docs-header";
-import { ProgressTracker } from "@/components/tool-ui/progress-tracker";
+import { ProgressTracker, ProgressTrackerReceipt } from "@/components/tool-ui/progress-tracker";
 
 <DocsHeader
   title="Progress Tracker"
@@ -105,12 +105,12 @@ The component automatically highlights the current step (in-progress or first pe
 
 ## Receipt Pattern
 
-Use the `choice` prop to render a terminal state after an operation completes, fails, or is cancelled. The receipt displays the full step history with an outcome indicator, which works well in conversation history.
+Use `<ProgressTrackerReceipt>` to render a terminal state after an operation completes, fails, or is cancelled. The receipt displays the full step history with an outcome indicator, which works well in conversation history.
 
 <Tabs items={["Success", "Failed", "Cancelled"]}>
   <Tab>
     <div className="not-prose mx-auto max-w-sm">
-      <ProgressTracker
+      <ProgressTrackerReceipt
         id="receipt-success-example"
         steps={[
           { id: "build", label: "Building", status: "completed" },
@@ -128,7 +128,7 @@ Use the `choice` prop to render a terminal state after an operation completes, f
   </Tab>
   <Tab>
     <div className="not-prose mx-auto max-w-sm">
-      <ProgressTracker
+      <ProgressTrackerReceipt
         id="receipt-failed-example"
         steps={[
           { id: "connect", label: "Connect to Database", status: "completed" },
@@ -146,7 +146,7 @@ Use the `choice` prop to render a terminal state after an operation completes, f
   </Tab>
   <Tab>
     <div className="not-prose mx-auto max-w-sm">
-      <ProgressTracker
+      <ProgressTrackerReceipt
         id="receipt-cancelled-example"
         steps={[
           { id: "step1", label: "Analyzing", status: "completed" },
@@ -261,17 +261,22 @@ pnpm dlx shadcn@latest add button
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
   ProgressTracker,
+  ProgressTrackerReceipt,
   ProgressTrackerErrorBoundary,
   parseSerializableProgressTracker,
   SerializableProgressTrackerSchema,
   type SerializableProgressTracker,
+  type ProgressTrackerChoice,
 } from "@/components/tool-ui/progress-tracker";
 
-export const ProgressTrackerTool = makeAssistantTool<SerializableProgressTracker>({
+export const ProgressTrackerTool = makeAssistantTool<
+  SerializableProgressTracker,
+  ProgressTrackerChoice
+>({
   toolName: "trackProgress",
   description: "Display real-time progress for multi-step operations",
   parameters: SerializableProgressTrackerSchema,
-  render: ({ args, toolCallId }) => {
+  render: ({ args, result, toolCallId }) => {
     if (!(args as any)?.steps) return null;
 
     const data = parseSerializableProgressTracker({
@@ -281,14 +286,18 @@ export const ProgressTrackerTool = makeAssistantTool<SerializableProgressTracker
 
     return (
       <ProgressTrackerErrorBoundary>
-        <ProgressTracker
-          {...data}
-          onResponseAction={async (actionId) => {
-            if (actionId === "cancel") {
-              console.log("Cancelled operation");
-            }
-          }}
-        />
+        {result ? (
+          <ProgressTrackerReceipt {...data} choice={result} />
+        ) : (
+          <ProgressTracker
+            {...data}
+            onResponseAction={async (actionId) => {
+              if (actionId === "cancel") {
+                console.log("Cancelled operation");
+              }
+            }}
+          />
+        )}
       </ProgressTrackerErrorBoundary>
     );
   },
@@ -326,10 +335,6 @@ Mount `<ProgressTrackerTool />` under `<AssistantRuntimeProvider>` to register t
     onBeforeResponseAction: {
       description: "Handler called before action execution (can prevent action by returning false)",
       type: "(actionId: string) => boolean | Promise<boolean>",
-    },
-    choice: {
-      description: "When provided, renders terminal state showing full step history with outcome indicator",
-      type: "ProgressTrackerChoice",
     },
   }}
 />

--- a/app/docs/question-flow/content.mdx
+++ b/app/docs/question-flow/content.mdx
@@ -27,17 +27,17 @@ import { DocsHeader } from "../_components/docs-header";
 
 ## Modes
 
-QuestionFlow has two modes:
+Question Flow has two modes:
 
 ### Progressive Mode
 
-Pass `step`, `title`, and `options` to render a single step. The AI controls progression by generating new steps based on user selections.
+Use `<QuestionFlowProgressive>` with `step`, `title`, and `options` to render a single step. The AI controls progression by generating new steps based on user selections.
 
 <QuestionFlowPresetExample preset="progressive" />
 
 ### Upfront Mode
 
-Pass `steps` with all step definitions. The component manages internal state and navigation.
+Use `<QuestionFlowUpfront>` with `steps` to define the entire flow. The component manages internal state and navigation.
 
 ### Multi-Select Steps
 
@@ -47,7 +47,7 @@ Set `selectionMode="multi"` to allow multiple selections per step.
 
 ## Receipt State
 
-Pass `choice` with a title and summary to show what was configured.
+Use `<QuestionFlowReceipt>` with `choice` to show what was configured.
 
 <QuestionFlowPresetExample preset="receipt" />
 
@@ -107,7 +107,9 @@ pnpm dlx shadcn@latest add button separator
 
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
-  QuestionFlow,
+  QuestionFlowProgressive,
+  QuestionFlowUpfront,
+  QuestionFlowReceipt,
   QuestionFlowErrorBoundary,
   parseSerializableQuestionFlow,
   SerializableQuestionFlowSchema,
@@ -129,23 +131,29 @@ export const ConfigureProjectTool = makeAssistantTool<
       id: (args as any)?.id ?? `wizard-${toolCallId}`,
     });
 
+    const receiptChoice = result
+      ? {
+          title: "Project configured",
+          summary: Object.entries(result).map(([key, values]) => ({
+            label: key,
+            value: values.join(", "),
+          })),
+        }
+      : null;
+
     return (
       <QuestionFlowErrorBoundary>
-        {result !== undefined ? (
-          <QuestionFlow
-            id={questionFlow.id}
-            choice={{
-              title: "Project configured",
-              summary: Object.entries(result).map(([key, values]) => ({
-                label: key,
-                value: values.join(", "),
-              })),
-            }}
-          />
-        ) : (
-          <QuestionFlow
+        {receiptChoice ? (
+          <QuestionFlowReceipt id={questionFlow.id} choice={receiptChoice} />
+        ) : "steps" in questionFlow ? (
+          <QuestionFlowUpfront
             {...questionFlow}
             onComplete={(answers) => addResult(answers)}
+          />
+        ) : (
+          <QuestionFlowProgressive
+            {...questionFlow}
+            onSelect={(ids) => addResult({ [questionFlow.title]: ids })}
           />
         )}
       </QuestionFlowErrorBoundary>

--- a/app/docs/quick-start/content.mdx
+++ b/app/docs/quick-start/content.mdx
@@ -232,6 +232,7 @@ When the tool is frontend/interactive, you register the tool **on the client** (
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
   OptionList,
+  OptionListReceipt,
   parseSerializableOptionList,
   SerializableOptionListSchema,
   type SerializableOptionList,
@@ -258,7 +259,7 @@ export const SelectFormatTool = makeAssistantTool<
     // Receipt state
     if (result !== undefined) {
       return (
-        <OptionList {...optionList} value={undefined} choice={result} />
+        <OptionListReceipt {...optionList} choice={result} />
       );
     }
 

--- a/app/docs/receipts/content.mdx
+++ b/app/docs/receipts/content.mdx
@@ -1,7 +1,7 @@
 import { DocsHeader } from "../_components/docs-header";
 import { MockThread, MockMessage } from "../_components/mock-thread";
-import { OptionList } from "@/components/tool-ui/option-list";
-import { ApprovalCard } from "@/components/tool-ui/approval-card";
+import { OptionListReceipt } from "@/components/tool-ui/option-list";
+import { ApprovalCardReceipt } from "@/components/tool-ui/approval-card";
 
 <DocsHeader
   title="Receipts"
@@ -22,7 +22,7 @@ Without receipts, consequential actions vanish into the conversation history. Th
         How would you like to handle the duplicate contacts?
       </span>
       <div className="mt-3">
-        <OptionList
+        <OptionListReceipt
           selectionMode="single"
           choice="merge"
           options={[
@@ -78,7 +78,7 @@ The action description stays in **imperative form** because it describes the req
 <div className="not-prose grid gap-4 sm:grid-cols-2 my-6">
   <div>
     <p className="text-sm text-muted-foreground mb-2">Approved action</p>
-    <ApprovalCard
+    <ApprovalCardReceipt
       id="receipt-approved-example"
       title="Back up database"
       choice="approved"
@@ -86,7 +86,7 @@ The action description stays in **imperative form** because it describes the req
   </div>
   <div>
     <p className="text-sm text-muted-foreground mb-2">Denied action</p>
-    <ApprovalCard
+    <ApprovalCardReceipt
       id="receipt-denied-example"
       title="Delete all project files"
       choice="denied"
@@ -104,13 +104,13 @@ The pattern is: **[Past-tense decision] — [Imperative action]**
 
 Several Tool UI components support receipt states:
 
-| Component | Receipt Prop | What It Shows |
-|-----------|--------------|---------------|
-| [Approval Card](/docs/approval-card) | `choice` | The decision and action title |
-| [Option List](/docs/option-list) | `choice` | Only the selected option(s) |
-| [Preferences Panel](/docs/preferences-panel) | `choice` | Summary of saved preferences |
-| [Progress Tracker](/docs/progress-tracker) | `choice` | Final status of the workflow |
-| [Order Summary](/docs/order-summary) | `choice` | Confirmed order details |
+| Component | Receipt Component | What It Shows |
+|-----------|-------------------|---------------|
+| [Approval Card](/docs/approval-card) | `ApprovalCardReceipt` | The decision and action title |
+| [Option List](/docs/option-list) | `OptionListReceipt` | Only the selected option(s) |
+| [Preferences Panel](/docs/preferences-panel) | `PreferencesPanelReceipt` | Summary of saved preferences |
+| [Progress Tracker](/docs/progress-tracker) | `ProgressTrackerReceipt` | Final status of the workflow |
+| [Order Summary](/docs/order-summary) | `OrderSummaryReceipt` | Confirmed order details |
 
 ## When to Use Receipts
 

--- a/components/tool-ui/approval-card/approval-card.tsx
+++ b/components/tool-ui/approval-card/approval-card.tsx
@@ -2,7 +2,11 @@
 
 import * as React from "react";
 import { cn, Separator } from "./_adapter";
-import type { ApprovalCardProps, ApprovalDecision } from "./schema";
+import type {
+  ApprovalCardProps,
+  ApprovalCardReceiptProps,
+  ApprovalDecision,
+} from "./schema";
 import { ActionButtons } from "../shared";
 import type { Action } from "../shared";
 import { icons, Check, X } from "lucide-react";
@@ -19,23 +23,18 @@ function getLucideIcon(name: string): LucideIcon | null {
   return Icon ?? null;
 }
 
-interface ApprovalCardReceiptProps {
-  id: string;
-  title: string;
-  choice: ApprovalDecision;
-  actionLabel?: string;
-  className?: string;
-}
-
-function ApprovalCardReceipt({
+export function ApprovalCardReceipt({
   id,
   title,
   choice,
-  actionLabel,
+  confirmLabel,
+  cancelLabel,
   className,
 }: ApprovalCardReceiptProps) {
   const isApproved = choice === "approved";
-  const displayLabel = actionLabel ?? (isApproved ? "Approved" : "Denied");
+  const displayLabel = isApproved
+    ? (confirmLabel ?? "Approved")
+    : (cancelLabel ?? "Denied");
 
   return (
     <div
@@ -119,7 +118,6 @@ export function ApprovalCard({
   cancelLabel,
   className,
   isLoading,
-  choice,
   onConfirm,
   onCancel,
 }: ApprovalCardProps) {
@@ -166,83 +164,70 @@ export function ApprovalCard({
     },
   ];
 
-  const viewKey = choice ? `receipt-${choice}` : "interactive";
-
   return (
-    <div key={viewKey} className="contents">
-      {choice ? (
-        <ApprovalCardReceipt
-          id={id}
-          title={title}
-          choice={choice}
-          className={className}
-        />
-      ) : (
-        <article
-          className={cn(
-            "@container/actions flex w-full min-w-64 max-w-md flex-col",
-            "text-foreground",
-            className,
-          )}
-          data-slot="approval-card"
-          data-tool-ui-id={id}
-          role="dialog"
-          aria-labelledby={`${id}-title`}
-          aria-describedby={description ? `${id}-description` : undefined}
-          onKeyDown={handleKeyDown}
-        >
-          <div className="bg-card flex w-full flex-col gap-4 rounded-2xl border p-5 shadow-xs">
-            <div className="flex items-start gap-3">
-              {Icon && (
-                <span
-                  className={cn(
-                    "flex size-10 shrink-0 items-center justify-center rounded-xl",
-                    isDestructive
-                      ? "bg-destructive/10 text-destructive"
-                      : "bg-primary/10 text-primary",
-                  )}
-                >
-                  <Icon className="size-5" />
-                </span>
-              )}
-              <div className="flex flex-1 flex-col gap-1">
-                <h2
-                  id={`${id}-title`}
-                  className="text-base font-semibold leading-tight"
-                >
-                  {title}
-                </h2>
-                {description && (
-                  <p
-                    id={`${id}-description`}
-                    className="text-muted-foreground text-sm"
-                  >
-                    {description}
-                  </p>
-                )}
-              </div>
-            </div>
-
-            {metadata && metadata.length > 0 && (
-              <>
-                <Separator />
-                <dl className="flex flex-col gap-2 text-sm">
-                  {metadata.map((item, index) => (
-                    <div key={index} className="flex justify-between gap-4">
-                      <dt className="text-muted-foreground shrink-0">
-                        {item.key}
-                      </dt>
-                      <dd className="min-w-0 truncate">{item.value}</dd>
-                    </div>
-                  ))}
-                </dl>
-              </>
-            )}
-
-            <ActionButtons actions={actions} onAction={handleAction} />
-          </div>
-        </article>
+    <article
+      className={cn(
+        "@container/actions flex w-full min-w-64 max-w-md flex-col",
+        "text-foreground",
+        className,
       )}
-    </div>
+      data-slot="approval-card"
+      data-tool-ui-id={id}
+      role="dialog"
+      aria-labelledby={`${id}-title`}
+      aria-describedby={description ? `${id}-description` : undefined}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="bg-card flex w-full flex-col gap-4 rounded-2xl border p-5 shadow-xs">
+        <div className="flex items-start gap-3">
+          {Icon && (
+            <span
+              className={cn(
+                "flex size-10 shrink-0 items-center justify-center rounded-xl",
+                isDestructive
+                  ? "bg-destructive/10 text-destructive"
+                  : "bg-primary/10 text-primary",
+              )}
+            >
+              <Icon className="size-5" />
+            </span>
+          )}
+          <div className="flex flex-1 flex-col gap-1">
+            <h2
+              id={`${id}-title`}
+              className="text-base font-semibold leading-tight"
+            >
+              {title}
+            </h2>
+            {description && (
+              <p
+                id={`${id}-description`}
+                className="text-muted-foreground text-sm"
+              >
+                {description}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {metadata && metadata.length > 0 && (
+          <>
+            <Separator />
+            <dl className="flex flex-col gap-2 text-sm">
+              {metadata.map((item, index) => (
+                <div key={index} className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground shrink-0">
+                    {item.key}
+                  </dt>
+                  <dd className="min-w-0 truncate">{item.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </>
+        )}
+
+        <ActionButtons actions={actions} onAction={handleAction} />
+      </div>
+    </article>
   );
 }

--- a/components/tool-ui/approval-card/index.tsx
+++ b/components/tool-ui/approval-card/index.tsx
@@ -1,10 +1,18 @@
-export { ApprovalCard, ApprovalCardProgress } from "./approval-card";
+export {
+  ApprovalCard,
+  ApprovalCardProgress,
+  ApprovalCardReceipt,
+} from "./approval-card";
 export { ApprovalCardErrorBoundary } from "./error-boundary";
 export {
   SerializableApprovalCardSchema,
+  SerializableApprovalCardReceiptSchema,
   parseSerializableApprovalCard,
+  parseSerializableApprovalCardReceipt,
   type SerializableApprovalCard,
+  type SerializableApprovalCardReceipt,
   type ApprovalCardProps,
+  type ApprovalCardReceiptProps,
   type ApprovalDecision,
   type MetadataItem,
 } from "./schema";

--- a/components/tool-ui/approval-card/schema.ts
+++ b/components/tool-ui/approval-card/schema.ts
@@ -29,12 +29,19 @@ export const SerializableApprovalCardSchema = z.object({
 
   confirmLabel: z.string().optional(),
   cancelLabel: z.string().optional(),
-
-  choice: ApprovalDecisionSchema.optional(),
 });
 
 export type SerializableApprovalCard = z.infer<
   typeof SerializableApprovalCardSchema
+>;
+
+export const SerializableApprovalCardReceiptSchema =
+  SerializableApprovalCardSchema.extend({
+    choice: ApprovalDecisionSchema,
+  });
+
+export type SerializableApprovalCardReceipt = z.infer<
+  typeof SerializableApprovalCardReceiptSchema
 >;
 
 export function parseSerializableApprovalCard(
@@ -43,9 +50,24 @@ export function parseSerializableApprovalCard(
   return parseWithSchema(SerializableApprovalCardSchema, input, "ApprovalCard");
 }
 
+export function parseSerializableApprovalCardReceipt(
+  input: unknown,
+): SerializableApprovalCardReceipt {
+  return parseWithSchema(
+    SerializableApprovalCardReceiptSchema,
+    input,
+    "ApprovalCardReceipt",
+  );
+}
+
 export interface ApprovalCardProps extends SerializableApprovalCard {
   className?: string;
   isLoading?: boolean;
   onConfirm?: () => void | Promise<void>;
   onCancel?: () => void | Promise<void>;
+}
+
+export interface ApprovalCardReceiptProps
+  extends SerializableApprovalCardReceipt {
+  className?: string;
 }

--- a/components/tool-ui/option-list/index.tsx
+++ b/components/tool-ui/option-list/index.tsx
@@ -1,14 +1,18 @@
-export { OptionList } from "./option-list";
+export { OptionList, OptionListReceipt } from "./option-list";
 export { OptionListErrorBoundary } from "./error-boundary";
 export type {
   OptionListProps,
+  OptionListReceiptProps,
   OptionListOption,
   OptionListSelection,
   SerializableOptionList,
+  SerializableOptionListReceipt,
 } from "./schema";
 export {
   OptionListOptionSchema,
   OptionListPropsSchema,
   SerializableOptionListSchema,
+  SerializableOptionListReceiptSchema,
   parseSerializableOptionList,
+  parseSerializableOptionListReceipt,
 } from "./schema";

--- a/components/tool-ui/option-list/option-list.tsx
+++ b/components/tool-ui/option-list/option-list.tsx
@@ -13,6 +13,7 @@ import type {
   OptionListProps,
   OptionListSelection,
   OptionListOption,
+  OptionListReceiptProps,
 } from "./schema";
 import { ActionButtons, normalizeActionsConfig } from "../shared";
 import type { Action } from "../shared";
@@ -227,6 +228,23 @@ function OptionListConfirmation({
   );
 }
 
+export function OptionListReceipt({
+  id,
+  options,
+  choice,
+  className,
+}: OptionListReceiptProps) {
+  const selectionMode = Array.isArray(choice) ? "multi" : "single";
+  return (
+    <OptionListConfirmation
+      id={id}
+      options={options}
+      selectedIds={parseSelectionToIdSet(choice, selectionMode)}
+      className={className}
+    />
+  );
+}
+
 export function OptionList({
   id,
   options,
@@ -235,7 +253,6 @@ export function OptionList({
   maxSelections,
   value,
   defaultValue,
-  choice,
   onChange,
   onConfirm,
   onCancel,
@@ -550,79 +567,65 @@ export function OptionList({
     selectedCount,
   ]);
 
-  const isReceipt = choice !== undefined && choice !== null;
-  const viewKey = isReceipt ? `receipt-${String(choice)}` : "interactive";
-
   return (
-    <div key={viewKey} className="contents">
-      {isReceipt ? (
-        <OptionListConfirmation
-          id={id}
-          options={options}
-          selectedIds={parseSelectionToIdSet(choice, selectionMode)}
-          className={className}
-        />
-      ) : (
-        <div
-          className={cn(
-            "@container/option-list flex w-full max-w-md min-w-80 flex-col gap-3",
-            "text-foreground",
-            className,
-          )}
-          data-slot="option-list"
-          data-tool-ui-id={id}
-          role="group"
-          aria-label="Option list"
-        >
-          <div
-            className={cn(
-              "group/list bg-card flex w-full flex-col overflow-hidden rounded-2xl border px-4 py-1.5 shadow-xs",
-            )}
-            role="listbox"
-            aria-multiselectable={selectionMode === "multi"}
-            onKeyDown={handleListboxKeyDown}
-          >
-            {optionStates.map(({ option, isSelected, isDisabled }, index) => {
-              return (
-                <Fragment key={option.id}>
-                  {index > 0 && (
-                    <Separator
-                      className="transition-opacity [@media(hover:hover)]:[&:has(+_:hover)]:opacity-0 [@media(hover:hover)]:[.peer:hover+&]:opacity-0"
-                      orientation="horizontal"
-                    />
-                  )}
-                  <OptionItem
-                    option={option}
-                    isSelected={isSelected}
-                    isDisabled={isDisabled}
-                    selectionMode={selectionMode}
-                    isFirst={index === 0}
-                    isLast={index === optionStates.length - 1}
-                    tabIndex={index === activeIndex ? 0 : -1}
-                    onFocus={() => setActiveIndex(index)}
-                    buttonRef={(el) => {
-                      optionRefs.current[index] = el;
-                    }}
-                    onToggle={() => toggleSelection(option.id)}
-                  />
-                </Fragment>
-              );
-            })}
-          </div>
-
-          <div className="@container/actions">
-            <ActionButtons
-              actions={actionsWithDisabledState}
-              align={normalizedFooterActions.align}
-              confirmTimeout={normalizedFooterActions.confirmTimeout}
-              onAction={handleFooterAction}
-              onBeforeAction={
-                hasCustomResponseActions ? onBeforeResponseAction : undefined
-              }
-            />
-          </div>
-        </div>
+    <div
+      className={cn(
+        "@container/option-list flex w-full max-w-md min-w-80 flex-col gap-3",
+        "text-foreground",
+        className,
       )}
+      data-slot="option-list"
+      data-tool-ui-id={id}
+      role="group"
+      aria-label="Option list"
+    >
+      <div
+        className={cn(
+          "group/list bg-card flex w-full flex-col overflow-hidden rounded-2xl border px-4 py-1.5 shadow-xs",
+        )}
+        role="listbox"
+        aria-multiselectable={selectionMode === "multi"}
+        onKeyDown={handleListboxKeyDown}
+      >
+        {optionStates.map(({ option, isSelected, isDisabled }, index) => {
+          return (
+            <Fragment key={option.id}>
+              {index > 0 && (
+                <Separator
+                  className="transition-opacity [@media(hover:hover)]:[&:has(+_:hover)]:opacity-0 [@media(hover:hover)]:[.peer:hover+&]:opacity-0"
+                  orientation="horizontal"
+                />
+              )}
+              <OptionItem
+                option={option}
+                isSelected={isSelected}
+                isDisabled={isDisabled}
+                selectionMode={selectionMode}
+                isFirst={index === 0}
+                isLast={index === optionStates.length - 1}
+                tabIndex={index === activeIndex ? 0 : -1}
+                onFocus={() => setActiveIndex(index)}
+                buttonRef={(el) => {
+                  optionRefs.current[index] = el;
+                }}
+                onToggle={() => toggleSelection(option.id)}
+              />
+            </Fragment>
+          );
+        })}
+      </div>
+
+      <div className="@container/actions">
+        <ActionButtons
+          actions={actionsWithDisabledState}
+          align={normalizedFooterActions.align}
+          confirmTimeout={normalizedFooterActions.confirmTimeout}
+          onAction={handleFooterAction}
+          onBeforeAction={
+            hasCustomResponseActions ? onBeforeResponseAction : undefined
+          }
+        />
+      </div>
     </div>
   );
 }

--- a/components/tool-ui/order-summary/index.tsx
+++ b/components/tool-ui/order-summary/index.tsx
@@ -1,13 +1,21 @@
-export { OrderSummary, OrderSummaryProgress } from "./order-summary";
+export {
+  OrderSummary,
+  OrderSummaryProgress,
+  OrderSummaryReceipt,
+} from "./order-summary";
 export { OrderSummaryErrorBoundary } from "./error-boundary";
 export {
   SerializableOrderSummarySchema,
+  SerializableOrderSummaryReceiptSchema,
   OrderItemSchema,
   PricingSchema,
   OrderDecisionSchema,
   parseSerializableOrderSummary,
+  parseSerializableOrderSummaryReceipt,
   type SerializableOrderSummary,
+  type SerializableOrderSummaryReceipt,
   type OrderSummaryProps,
+  type OrderSummaryReceiptProps,
   type OrderItem,
   type Pricing,
   type OrderDecision,

--- a/components/tool-ui/order-summary/order-summary.tsx
+++ b/components/tool-ui/order-summary/order-summary.tsx
@@ -4,7 +4,12 @@ import * as React from "react";
 import { useCallback } from "react";
 import { CheckCircle, Package } from "lucide-react";
 import { cn, Separator, Skeleton } from "./_adapter";
-import type { OrderSummaryProps, OrderItem, Pricing } from "./schema";
+import type {
+  OrderSummaryProps,
+  OrderSummaryReceiptProps,
+  OrderItem,
+  Pricing,
+} from "./schema";
 import { ActionButtons } from "../shared";
 
 const defaultActions = [
@@ -173,19 +178,70 @@ function ReceiptBadge({
   );
 }
 
-export function OrderSummary({
+export function OrderSummaryReceipt({
   id,
   title = "Order Summary",
   items,
   pricing,
   choice,
   className,
+}: OrderSummaryReceiptProps) {
+  const titleId = `${id}-title`;
+
+  return (
+    <article
+      data-slot="order-summary"
+      data-tool-ui-id={id}
+      data-receipt="true"
+      aria-labelledby={titleId}
+      className={cn("flex max-w-md min-w-80 flex-col gap-3", className)}
+    >
+      <div className="text-card-foreground rounded-lg border bg-card/60 shadow-sm">
+        <div className="space-y-4 p-4 opacity-95">
+          <div>
+            <h2
+              id={titleId}
+              className="flex items-center gap-2 text-base font-semibold"
+            >
+              <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-500" />
+              {title}
+            </h2>
+            <ReceiptBadge
+              orderId={choice.orderId}
+              confirmedAt={choice.confirmedAt}
+            />
+          </div>
+
+          <div className="space-y-3">
+            {items.map((item) => (
+              <OrderItemRow
+                key={item.id}
+                item={item}
+                currency={pricing.currency ?? "USD"}
+              />
+            ))}
+          </div>
+
+          <Separator />
+
+          <PricingBreakdown pricing={pricing} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function OrderSummary({
+  id,
+  title = "Order Summary",
+  items,
+  pricing,
+  className,
   isLoading = false,
   responseActions,
   onResponseAction,
 }: OrderSummaryProps) {
   const titleId = `${id}-title`;
-  const isReceipt = choice !== undefined;
   const actions = responseActions ?? defaultActions;
 
   const handleAction = useCallback(
@@ -205,25 +261,18 @@ export function OrderSummary({
     >
       <div
         className={cn(
-          "text-card-foreground rounded-lg border shadow-sm",
-          isReceipt ? "bg-card/60" : "bg-card",
+          "text-card-foreground rounded-lg border bg-card shadow-sm",
           isLoading && "pointer-events-none opacity-70",
         )}
       >
-        <div className={cn("space-y-4 p-4", isReceipt && "opacity-95")}>
+        <div className="space-y-4 p-4">
           <div>
-            <h2 id={titleId} className="flex items-center gap-2 text-base font-semibold">
-              {isReceipt && (
-                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-500" />
-              )}
+            <h2
+              id={titleId}
+              className="flex items-center gap-2 text-base font-semibold"
+            >
               {title}
             </h2>
-            {isReceipt && (
-              <ReceiptBadge
-                orderId={choice.orderId}
-                confirmedAt={choice.confirmedAt}
-              />
-            )}
           </div>
 
           <div className="space-y-3">
@@ -241,12 +290,9 @@ export function OrderSummary({
           <PricingBreakdown pricing={pricing} />
         </div>
       </div>
-
-      {!isReceipt && (
-        <div className="@container/actions">
-          <ActionButtons actions={actions} onAction={handleAction} />
-        </div>
-      )}
+      <div className="@container/actions">
+        <ActionButtons actions={actions} onAction={handleAction} />
+      </div>
     </article>
   );
 }

--- a/components/tool-ui/order-summary/schema.ts
+++ b/components/tool-ui/order-summary/schema.ts
@@ -40,17 +40,35 @@ export const SerializableOrderSummarySchema = z.object({
   title: z.string().optional(),
   items: z.array(OrderItemSchema).min(1),
   pricing: PricingSchema,
-  choice: OrderDecisionSchema.optional(),
 });
 
 export type SerializableOrderSummary = z.infer<
   typeof SerializableOrderSummarySchema
 >;
 
+export const SerializableOrderSummaryReceiptSchema =
+  SerializableOrderSummarySchema.extend({
+    choice: OrderDecisionSchema,
+  });
+
+export type SerializableOrderSummaryReceipt = z.infer<
+  typeof SerializableOrderSummaryReceiptSchema
+>;
+
 export function parseSerializableOrderSummary(
   input: unknown
 ): SerializableOrderSummary {
   return parseWithSchema(SerializableOrderSummarySchema, input, "OrderSummary");
+}
+
+export function parseSerializableOrderSummaryReceipt(
+  input: unknown
+): SerializableOrderSummaryReceipt {
+  return parseWithSchema(
+    SerializableOrderSummaryReceiptSchema,
+    input,
+    "OrderSummaryReceipt"
+  );
 }
 
 export interface OrderSummaryProps extends SerializableOrderSummary {
@@ -63,4 +81,9 @@ export interface OrderSummaryProps extends SerializableOrderSummary {
     disabled?: boolean;
   }>;
   onResponseAction?: (actionId: string) => void;
+}
+
+export interface OrderSummaryReceiptProps
+  extends SerializableOrderSummaryReceipt {
+  className?: string;
 }

--- a/components/tool-ui/progress-tracker/index.tsx
+++ b/components/tool-ui/progress-tracker/index.tsx
@@ -1,11 +1,19 @@
-export { ProgressTracker, ProgressTrackerProgress } from "./progress-tracker";
+export {
+  ProgressTracker,
+  ProgressTrackerProgress,
+  ProgressTrackerReceipt,
+} from "./progress-tracker";
 export { ProgressTrackerErrorBoundary } from "./error-boundary";
 export {
   SerializableProgressTrackerSchema,
+  SerializableProgressTrackerReceiptSchema,
   parseSerializableProgressTracker,
+  parseSerializableProgressTrackerReceipt,
   ProgressStepSchema,
   type SerializableProgressTracker,
+  type SerializableProgressTrackerReceipt,
   type ProgressTrackerProps,
+  type ProgressTrackerReceiptProps,
   type ProgressTrackerChoice,
   type ProgressStep,
 } from "./schema";

--- a/components/tool-ui/progress-tracker/schema.ts
+++ b/components/tool-ui/progress-tracker/schema.ts
@@ -25,10 +25,6 @@ export type ProgressStep = z.infer<typeof ProgressStepSchema>;
 export const SerializableProgressTrackerSchema = ToolUISurfaceSchema.extend({
   steps: z.array(ProgressStepSchema).min(1),
   elapsedTime: z.number().optional(),
-  /**
-   * When set, renders the component in receipt state showing the workflow outcome.
-   */
-  choice: ToolUIReceiptSchema.optional(),
   responseActions: z
     .union([z.array(SerializableActionSchema), SerializableActionsConfigSchema])
     .optional(),
@@ -36,6 +32,17 @@ export const SerializableProgressTrackerSchema = ToolUISurfaceSchema.extend({
 
 export type SerializableProgressTracker = z.infer<
   typeof SerializableProgressTrackerSchema
+>;
+
+export const SerializableProgressTrackerReceiptSchema =
+  ToolUISurfaceSchema.extend({
+    steps: z.array(ProgressStepSchema).min(1),
+    elapsedTime: z.number().optional(),
+    choice: ToolUIReceiptSchema,
+  });
+
+export type SerializableProgressTrackerReceipt = z.infer<
+  typeof SerializableProgressTrackerReceiptSchema
 >;
 
 export function parseSerializableProgressTracker(
@@ -48,9 +55,24 @@ export function parseSerializableProgressTracker(
   );
 }
 
+export function parseSerializableProgressTrackerReceipt(
+  input: unknown,
+): SerializableProgressTrackerReceipt {
+  return parseWithSchema(
+    SerializableProgressTrackerReceiptSchema,
+    input,
+    "ProgressTrackerReceipt",
+  );
+}
+
 export interface ProgressTrackerProps extends SerializableProgressTracker {
   className?: string;
   responseActions?: ActionsProp;
   onResponseAction?: (actionId: string) => void | Promise<void>;
   onBeforeResponseAction?: (actionId: string) => boolean | Promise<boolean>;
+}
+
+export interface ProgressTrackerReceiptProps
+  extends SerializableProgressTrackerReceipt {
+  className?: string;
 }

--- a/components/tool-ui/question-flow/index.tsx
+++ b/components/tool-ui/question-flow/index.tsx
@@ -1,4 +1,9 @@
-export { QuestionFlow, QuestionFlowProgress } from "./question-flow";
+export {
+  QuestionFlowProgressive,
+  QuestionFlowUpfront,
+  QuestionFlowReceipt,
+  QuestionFlowProgress,
+} from "./question-flow";
 export { QuestionFlowErrorBoundary } from "./error-boundary";
 export {
   SerializableQuestionFlowSchema,
@@ -14,7 +19,6 @@ export {
   type SerializableProgressiveMode,
   type SerializableUpfrontMode,
   type SerializableReceiptMode,
-  type QuestionFlowProps,
   type QuestionFlowProgressiveProps,
   type QuestionFlowUpfrontProps,
   type QuestionFlowReceiptProps,

--- a/components/tool-ui/question-flow/question-flow.tsx
+++ b/components/tool-ui/question-flow/question-flow.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import type { KeyboardEvent } from "react";
 import type {
-  QuestionFlowProps,
   QuestionFlowProgressiveProps,
   QuestionFlowUpfrontProps,
   QuestionFlowReceiptProps,
@@ -206,7 +205,7 @@ function QuestionFlowSkeleton({ className }: { className?: string }) {
   );
 }
 
-function QuestionFlowReceipt({
+export function QuestionFlowReceipt({
   id,
   choice,
   className,
@@ -589,7 +588,7 @@ function StepContent({
   );
 }
 
-function QuestionFlowProgressive({
+export function QuestionFlowProgressive({
   id,
   step,
   title,
@@ -659,7 +658,7 @@ function QuestionFlowProgressive({
   );
 }
 
-function QuestionFlowUpfront({
+export function QuestionFlowUpfront({
   id,
   steps,
   onStepChange,
@@ -789,18 +788,6 @@ function QuestionFlowUpfront({
       transitionDirection={transitionDirection}
     />
   );
-}
-
-export function QuestionFlow(props: QuestionFlowProps) {
-  if ("choice" in props && props.choice !== undefined) {
-    return <QuestionFlowReceipt {...(props as QuestionFlowReceiptProps)} />;
-  }
-
-  if ("steps" in props && props.steps !== undefined) {
-    return <QuestionFlowUpfront {...(props as QuestionFlowUpfrontProps)} />;
-  }
-
-  return <QuestionFlowProgressive {...(props as QuestionFlowProgressiveProps)} />;
 }
 
 export { QuestionFlowSkeleton as QuestionFlowProgress };

--- a/lib/docs/preview-config.tsx
+++ b/lib/docs/preview-config.tsx
@@ -5,7 +5,10 @@ import { useState } from "react";
 import type { ComponentProps, ComponentType, ReactNode } from "react";
 import type { PresetWithCodeGen } from "@/lib/presets/types";
 
-import type { ApprovalCard } from "@/components/tool-ui/approval-card";
+import type {
+  ApprovalCardProps,
+  ApprovalCardReceiptProps,
+} from "@/components/tool-ui/approval-card";
 import type { Chart } from "@/components/tool-ui/chart";
 import type { Citation } from "@/components/tool-ui/citation";
 import type { CodeBlock } from "@/components/tool-ui/code-block";
@@ -17,15 +20,28 @@ import type { Audio } from "@/components/tool-ui/audio";
 import type { LinkPreview } from "@/components/tool-ui/link-preview";
 import type { MessageDraft } from "@/components/tool-ui/message-draft";
 import type { ItemCarousel } from "@/components/tool-ui/item-carousel";
-import type { OptionList } from "@/components/tool-ui/option-list";
-import type { OrderSummary } from "@/components/tool-ui/order-summary";
+import type {
+  OptionListProps,
+  OptionListReceiptProps,
+} from "@/components/tool-ui/option-list";
+import type {
+  OrderSummaryProps,
+  OrderSummaryReceiptProps,
+} from "@/components/tool-ui/order-summary";
 import type { ParameterSlider } from "@/components/tool-ui/parameter-slider";
 import type { Plan } from "@/components/tool-ui/plan";
 import type { PreferencesPanel } from "@/components/tool-ui/preferences-panel";
-import type { ProgressTracker } from "@/components/tool-ui/progress-tracker";
+import type {
+  ProgressTrackerProps,
+  ProgressTrackerReceiptProps,
+} from "@/components/tool-ui/progress-tracker";
 import type { StatsDisplay } from "@/components/tool-ui/stats-display";
 import type { Terminal } from "@/components/tool-ui/terminal";
-import type { QuestionFlow } from "@/components/tool-ui/question-flow";
+import type {
+  QuestionFlowProgressiveProps,
+  QuestionFlowUpfrontProps,
+  QuestionFlowReceiptProps,
+} from "@/components/tool-ui/question-flow";
 import type { WeatherWidget } from "@/components/tool-ui/weather-widget";
 
 import {
@@ -102,10 +118,19 @@ import {
   weatherWidgetPresets,
   type WeatherWidgetPresetName,
 } from "@/lib/presets/weather-widget";
-import type { SerializableUpfrontMode } from "@/components/tool-ui/question-flow";
+import type {
+  SerializableProgressiveMode,
+  SerializableUpfrontMode,
+  SerializableReceiptMode,
+} from "@/components/tool-ui/question-flow";
 
 const DynamicApprovalCard = dynamic(() =>
-  import("@/components/tool-ui/approval-card").then((m) => m.ApprovalCard)
+  import("@/components/tool-ui/approval-card").then((m) => m.ApprovalCard),
+);
+const DynamicApprovalCardReceipt = dynamic(() =>
+  import("@/components/tool-ui/approval-card").then(
+    (m) => m.ApprovalCardReceipt,
+  ),
 );
 const DynamicChart = dynamic(() =>
   import("@/components/tool-ui/chart").then((m) => m.Chart)
@@ -144,10 +169,18 @@ const DynamicItemCarousel = dynamic(() =>
   import("@/components/tool-ui/item-carousel").then((m) => m.ItemCarousel)
 );
 const DynamicOptionList = dynamic(() =>
-  import("@/components/tool-ui/option-list").then((m) => m.OptionList)
+  import("@/components/tool-ui/option-list").then((m) => m.OptionList),
+);
+const DynamicOptionListReceipt = dynamic(() =>
+  import("@/components/tool-ui/option-list").then((m) => m.OptionListReceipt),
 );
 const DynamicOrderSummary = dynamic(() =>
-  import("@/components/tool-ui/order-summary").then((m) => m.OrderSummary)
+  import("@/components/tool-ui/order-summary").then((m) => m.OrderSummary),
+);
+const DynamicOrderSummaryReceipt = dynamic(() =>
+  import("@/components/tool-ui/order-summary").then(
+    (m) => m.OrderSummaryReceipt,
+  ),
 );
 const DynamicParameterSlider = dynamic(() =>
   import("@/components/tool-ui/parameter-slider").then((m) => m.ParameterSlider)
@@ -159,7 +192,14 @@ const DynamicPreferencesPanel = dynamic(() =>
   import("@/components/tool-ui/preferences-panel").then((m) => m.PreferencesPanel)
 );
 const DynamicProgressTracker = dynamic(() =>
-  import("@/components/tool-ui/progress-tracker").then((m) => m.ProgressTracker)
+  import("@/components/tool-ui/progress-tracker").then(
+    (m) => m.ProgressTracker,
+  ),
+);
+const DynamicProgressTrackerReceipt = dynamic(() =>
+  import("@/components/tool-ui/progress-tracker").then(
+    (m) => m.ProgressTrackerReceipt,
+  ),
 );
 const DynamicStatsDisplay = dynamic(() =>
   import("@/components/tool-ui/stats-display").then((m) => m.StatsDisplay)
@@ -167,8 +207,20 @@ const DynamicStatsDisplay = dynamic(() =>
 const DynamicTerminal = dynamic(() =>
   import("@/components/tool-ui/terminal").then((m) => m.Terminal)
 );
-const DynamicQuestionFlow = dynamic(() =>
-  import("@/components/tool-ui/question-flow").then((m) => m.QuestionFlow)
+const DynamicQuestionFlowProgressive = dynamic(() =>
+  import("@/components/tool-ui/question-flow").then(
+    (m) => m.QuestionFlowProgressive,
+  ),
+);
+const DynamicQuestionFlowUpfront = dynamic(() =>
+  import("@/components/tool-ui/question-flow").then(
+    (m) => m.QuestionFlowUpfront,
+  ),
+);
+const DynamicQuestionFlowReceipt = dynamic(() =>
+  import("@/components/tool-ui/question-flow").then(
+    (m) => m.QuestionFlowReceipt,
+  ),
 );
 const DynamicWeatherWidget = dynamic(() =>
   import("@/components/tool-ui/weather-widget").then((m) => m.WeatherWidget)
@@ -202,7 +254,7 @@ function QuestionFlowUpfrontWithReceipt({
       .replace(/\b\w/g, (c) => c.toUpperCase());
 
     return (
-      <DynamicQuestionFlow
+      <DynamicQuestionFlowReceipt
         id={data.id}
         choice={{
           title,
@@ -213,7 +265,7 @@ function QuestionFlowUpfrontWithReceipt({
   }
 
   return (
-    <DynamicQuestionFlow
+    <DynamicQuestionFlowUpfront
       {...data}
       onComplete={(answers: Record<string, string[]>) =>
         setCompletedAnswers(answers)
@@ -298,12 +350,23 @@ export const previewConfigs: Record<
       preamble: "I'll need your confirmation before proceeding:",
     },
     renderComponent: ({ data, state, setState }) => {
-      const cardData = data as ComponentProps<typeof ApprovalCard>;
-      const choice = state.selection as "approved" | "denied" | undefined;
+      const cardData = data as ApprovalCardProps | ApprovalCardReceiptProps;
+      const resolvedChoice =
+        ("choice" in cardData ? cardData.choice : undefined) ??
+        (state.selection as "approved" | "denied" | undefined);
+
+      if (resolvedChoice) {
+        return (
+          <DynamicApprovalCardReceipt
+            {...(cardData as ApprovalCardProps)}
+            choice={resolvedChoice}
+          />
+        );
+      }
+
       return (
         <DynamicApprovalCard
-          {...cardData}
-          choice={cardData.choice ?? choice}
+          {...(cardData as ApprovalCardProps)}
           onConfirm={() => setState({ selection: "approved" })}
           onCancel={() => setState({ selection: "denied" })}
         />
@@ -559,10 +622,19 @@ export const previewConfigs: Record<
       preamble: "What sounds good?",
     },
     renderComponent: ({ data, state, setState }) => {
-      const listData = data as Parameters<typeof OptionList>[0];
+      const listData = data as OptionListProps | OptionListReceiptProps;
+      if ("choice" in listData) {
+        return (
+          <DynamicOptionListReceipt
+            {...listData}
+            id="option-list-preview"
+          />
+        );
+      }
+
       return (
         <DynamicOptionList
-          {...listData}
+          {...(listData as OptionListProps)}
           id="option-list-preview"
           value={state.selection}
           onChange={(selection) => setState({ selection })}
@@ -583,10 +655,13 @@ export const previewConfigs: Record<
       preamble: "Here's the order summary for your review:",
     },
     renderComponent: ({ data }) => {
-      const orderData = data as Parameters<typeof OrderSummary>[0];
+      const orderData = data as OrderSummaryProps | OrderSummaryReceiptProps;
+      if ("choice" in orderData) {
+        return <DynamicOrderSummaryReceipt {...orderData} />;
+      }
       return (
         <DynamicOrderSummary
-          {...orderData}
+          {...(orderData as OrderSummaryProps)}
           onResponseAction={(actionId) =>
             console.log("Response action:", actionId)
           }
@@ -689,10 +764,14 @@ export const previewConfigs: Record<
       preamble: "Starting deployment process:",
     },
     renderComponent: ({ data }) => {
-      const trackerData = data as Parameters<typeof ProgressTracker>[0];
+      const trackerData =
+        data as ProgressTrackerProps | ProgressTrackerReceiptProps;
+      if ("choice" in trackerData) {
+        return <DynamicProgressTrackerReceipt {...trackerData} />;
+      }
       return (
         <DynamicProgressTracker
-          {...trackerData}
+          {...(trackerData as ProgressTrackerProps)}
           onResponseAction={(actionId) =>
             console.log("Response action:", actionId)
           }
@@ -755,12 +834,20 @@ export const previewConfigs: Record<
       preamble: "Let's configure your project step by step:",
     },
     renderComponent: ({ data, presetName }) => {
-      const flowData = data as Parameters<typeof QuestionFlow>[0];
+      const flowData = data as
+        | SerializableProgressiveMode
+        | SerializableUpfrontMode
+        | SerializableReceiptMode;
       const isUpfront = "steps" in flowData && flowData.steps !== undefined;
       const isReceipt = "choice" in flowData && flowData.choice !== undefined;
 
       if (isReceipt) {
-        return <DynamicQuestionFlow key={presetName} {...flowData} />;
+        return (
+          <DynamicQuestionFlowReceipt
+            key={presetName}
+            {...(flowData as SerializableReceiptMode)}
+          />
+        );
       }
 
       if (isUpfront) {
@@ -773,9 +860,9 @@ export const previewConfigs: Record<
       }
 
       return (
-        <DynamicQuestionFlow
+        <DynamicQuestionFlowProgressive
           key={presetName}
-          {...flowData}
+          {...(flowData as SerializableProgressiveMode)}
           onSelect={(ids: string[]) => console.log("Selected:", ids)}
           onBack={() => console.log("Go back")}
         />

--- a/lib/presets/approval-card.ts
+++ b/lib/presets/approval-card.ts
@@ -1,4 +1,7 @@
-import type { SerializableApprovalCard } from "@/components/tool-ui/approval-card";
+import type {
+  SerializableApprovalCard,
+  SerializableApprovalCardReceipt,
+} from "@/components/tool-ui/approval-card";
 import type { PresetWithCodeGen } from "./types";
 
 export type ApprovalCardPresetName =
@@ -8,7 +11,11 @@ export type ApprovalCardPresetName =
   | "receipt-approved"
   | "receipt-denied";
 
-function generateApprovalCardCode(data: SerializableApprovalCard): string {
+type ApprovalCardPresetData =
+  | SerializableApprovalCard
+  | SerializableApprovalCardReceipt;
+
+function generateApprovalCardCode(data: ApprovalCardPresetData): string {
   const props: string[] = [];
 
   props.push(`  id="${data.id}"`);
@@ -40,19 +47,20 @@ function generateApprovalCardCode(data: SerializableApprovalCard): string {
     props.push(`  cancelLabel="${data.cancelLabel}"`);
   }
 
-  if (data.choice) {
+  if ("choice" in data) {
     props.push(`  choice="${data.choice}"`);
-  } else {
-    props.push(`  onConfirm={() => console.log("Approved")}`);
-    props.push(`  onCancel={() => console.log("Denied")}`);
+    return `<ApprovalCardReceipt\n${props.join("\n")}\n/>`;
   }
+
+  props.push(`  onConfirm={() => console.log("Approved")}`);
+  props.push(`  onCancel={() => console.log("Denied")}`);
 
   return `<ApprovalCard\n${props.join("\n")}\n/>`;
 }
 
 export const approvalCardPresets: Record<
   ApprovalCardPresetName,
-  PresetWithCodeGen<SerializableApprovalCard>
+  PresetWithCodeGen<ApprovalCardPresetData>
 > = {
   deploy: {
     description: "Simple deployment approval",
@@ -102,7 +110,7 @@ export const approvalCardPresets: Record<
       title: "Back up database",
       choice: "approved",
       confirmLabel: "Approved",
-    } satisfies SerializableApprovalCard,
+    } satisfies SerializableApprovalCardReceipt,
     generateExampleCode: generateApprovalCardCode,
   },
   "receipt-denied": {
@@ -112,7 +120,7 @@ export const approvalCardPresets: Record<
       title: "Delete all project files",
       choice: "denied",
       cancelLabel: "Denied",
-    } satisfies SerializableApprovalCard,
+    } satisfies SerializableApprovalCardReceipt,
     generateExampleCode: generateApprovalCardCode,
   },
 };

--- a/lib/presets/option-list.ts
+++ b/lib/presets/option-list.ts
@@ -1,4 +1,7 @@
-import type { SerializableOptionList } from "@/components/tool-ui/option-list";
+import type {
+  SerializableOptionList,
+  SerializableOptionListReceipt,
+} from "@/components/tool-ui/option-list";
 import type { PresetWithCodeGen } from "./types";
 
 export type OptionListPresetName =
@@ -8,7 +11,11 @@ export type OptionListPresetName =
   | "receipt"
   | "destructive";
 
-function generateOptionListCode(data: SerializableOptionList): string {
+type OptionListPresetData =
+  | SerializableOptionList
+  | SerializableOptionListReceipt;
+
+function generateOptionListCode(data: OptionListPresetData): string {
   const props: string[] = [];
 
   props.push(
@@ -27,8 +34,9 @@ function generateOptionListCode(data: SerializableOptionList): string {
     props.push(`  maxSelections={${data.maxSelections}}`);
   }
 
-  if (data.choice) {
+  if ("choice" in data) {
     props.push(`  choice="${data.choice}"`);
+    return `<OptionListReceipt\n${props.join("\n")}\n/>`;
   }
 
   if (data.responseActions) {
@@ -44,7 +52,10 @@ function generateOptionListCode(data: SerializableOptionList): string {
   return `<OptionList\n${props.join("\n")}\n/>`;
 }
 
-export const optionListPresets: Record<OptionListPresetName, PresetWithCodeGen<SerializableOptionList>> = {
+export const optionListPresets: Record<
+  OptionListPresetName,
+  PresetWithCodeGen<OptionListPresetData>
+> = {
   "max-selections": {
     description: "Pick two (you can't have all three)",
     data: {
@@ -148,7 +159,7 @@ export const optionListPresets: Record<OptionListPresetName, PresetWithCodeGen<S
       ],
       selectionMode: "single",
       choice: "drive",
-    } satisfies SerializableOptionList,
+    } satisfies SerializableOptionListReceipt,
     generateExampleCode: generateOptionListCode,
   },
   destructive: {

--- a/lib/presets/order-summary.ts
+++ b/lib/presets/order-summary.ts
@@ -1,4 +1,7 @@
-import type { SerializableOrderSummary } from "@/components/tool-ui/order-summary";
+import type {
+  SerializableOrderSummary,
+  SerializableOrderSummaryReceipt,
+} from "@/components/tool-ui/order-summary";
 import type { PresetWithCodeGen } from "./types";
 
 export type OrderSummaryPresetName =
@@ -8,7 +11,11 @@ export type OrderSummaryPresetName =
   | "receipt"
   | "international";
 
-function generateOrderSummaryCode(data: SerializableOrderSummary): string {
+type OrderSummaryPresetData =
+  | SerializableOrderSummary
+  | SerializableOrderSummaryReceipt;
+
+function generateOrderSummaryCode(data: OrderSummaryPresetData): string {
   const props: string[] = [];
 
   props.push(`  id="${data.id}"`);
@@ -25,10 +32,11 @@ function generateOrderSummaryCode(data: SerializableOrderSummary): string {
     `  pricing={${JSON.stringify(data.pricing, null, 4).replace(/\n/g, "\n  ")}}`
   );
 
-  if (data.choice) {
+  if ("choice" in data) {
     props.push(
       `  choice={${JSON.stringify(data.choice, null, 4).replace(/\n/g, "\n  ")}}`
     );
+    return `<OrderSummaryReceipt\n${props.join("\n")}\n/>`;
   }
 
   return `<OrderSummary\n${props.join("\n")}\n/>`;
@@ -36,7 +44,7 @@ function generateOrderSummaryCode(data: SerializableOrderSummary): string {
 
 export const orderSummaryPresets: Record<
   OrderSummaryPresetName,
-  PresetWithCodeGen<SerializableOrderSummary>
+  PresetWithCodeGen<OrderSummaryPresetData>
 > = {
   default: {
     description: "Standard order with multiple items and tax",
@@ -181,7 +189,7 @@ export const orderSummaryPresets: Record<
         orderId: "ORD-2024-8847",
         confirmedAt: "2024-12-15T14:32:00Z",
       },
-    } satisfies SerializableOrderSummary,
+    } satisfies SerializableOrderSummaryReceipt,
     generateExampleCode: generateOrderSummaryCode,
   },
 

--- a/lib/presets/progress-tracker.ts
+++ b/lib/presets/progress-tracker.ts
@@ -1,4 +1,7 @@
-import type { SerializableProgressTracker } from "@/components/tool-ui/progress-tracker";
+import type {
+  SerializableProgressTracker,
+  SerializableProgressTrackerReceipt,
+} from "@/components/tool-ui/progress-tracker";
 import type { PresetWithCodeGen } from "./types";
 
 export type ProgressTrackerPresetName =
@@ -9,10 +12,13 @@ export type ProgressTrackerPresetName =
   | "receipt"
   | "receipt-failed";
 
-type ProgressTrackerPreset = PresetWithCodeGen<SerializableProgressTracker>;
+type ProgressTrackerPresetData =
+  | SerializableProgressTracker
+  | SerializableProgressTrackerReceipt;
+type ProgressTrackerPreset = PresetWithCodeGen<ProgressTrackerPresetData>;
 
 function generateProgressTrackerCode(
-  data: SerializableProgressTracker,
+  data: ProgressTrackerPresetData,
 ): string {
   const props: string[] = [];
 
@@ -25,10 +31,11 @@ function generateProgressTrackerCode(
     props.push(`  elapsedTime={${data.elapsedTime}}`);
   }
 
-  if (data.choice) {
+  if ("choice" in data) {
     props.push(
       `  choice={${JSON.stringify(data.choice, null, 4).replace(/\n/g, "\n  ")}}`,
     );
+    return `<ProgressTrackerReceipt\n${props.join("\n")}\n/>`;
   }
 
   if (data.responseActions) {
@@ -203,7 +210,7 @@ export const progressTrackerPresets = {
         summary: "Deployment complete",
         at: new Date().toISOString(),
       },
-    } satisfies SerializableProgressTracker,
+    } satisfies SerializableProgressTrackerReceipt,
     generateExampleCode: generateProgressTrackerCode,
   },
   "receipt-failed": {
@@ -239,7 +246,7 @@ export const progressTrackerPresets = {
         summary: "Migration failed",
         at: new Date().toISOString(),
       },
-    } satisfies SerializableProgressTracker,
+    } satisfies SerializableProgressTrackerReceipt,
     generateExampleCode: generateProgressTrackerCode,
   },
 } satisfies Record<string, ProgressTrackerPreset>;

--- a/lib/presets/question-flow.ts
+++ b/lib/presets/question-flow.ts
@@ -34,7 +34,7 @@ function generateProgressiveCode(data: SerializableProgressiveMode): string {
   props.push(`  onSelect={(ids) => console.log("Selected:", ids)}`);
   props.push(`  onBack={() => console.log("Go back")}`);
 
-  return `<QuestionFlow\n${props.join("\n")}\n/>`;
+  return `<QuestionFlowProgressive\n${props.join("\n")}\n/>`;
 }
 
 function generateUpfrontCode(data: SerializableUpfrontMode): string {
@@ -46,7 +46,7 @@ function generateUpfrontCode(data: SerializableUpfrontMode): string {
   );
   props.push(`  onComplete={(answers) => console.log("Complete:", answers)}`);
 
-  return `<QuestionFlow\n${props.join("\n")}\n/>`;
+  return `<QuestionFlowUpfront\n${props.join("\n")}\n/>`;
 }
 
 function generateReceiptCode(data: SerializableReceiptMode): string {
@@ -57,7 +57,7 @@ function generateReceiptCode(data: SerializableReceiptMode): string {
     `  choice={${JSON.stringify(data.choice, null, 4).replace(/\n/g, "\n  ")}}`,
   );
 
-  return `<QuestionFlow\n${props.join("\n")}\n/>`;
+  return `<QuestionFlowReceipt\n${props.join("\n")}\n/>`;
 }
 
 function generateQuestionFlowCode(data: SerializableQuestionFlow): string {


### PR DESCRIPTION
## Summary\n- split receipt state into explicit components for OptionList, ApprovalCard, ProgressTracker, OrderSummary\n- expose new receipt schemas/parsers and update presets/codegen\n- update docs, gallery, and preview config to use receipt components\n- replace QuestionFlow wrapper with explicit progressive/upfront/receipt exports\n\n## Testing\n- pnpm typecheck