### PR TITLE
Add receipt components for PreferencesPanel and MessageDraft

### DIFF
--- a/app/docs/message-draft/content.mdx
+++ b/app/docs/message-draft/content.mdx
@@ -1,5 +1,8 @@
 import { DocsHeader } from "../_components/docs-header";
-import { MessageDraft } from "@/components/tool-ui/message-draft";
+import {
+  MessageDraft,
+  MessageDraftReceipt,
+} from "@/components/tool-ui/message-draft";
 
 <DocsHeader
   title="Message Draft"
@@ -156,12 +159,12 @@ The grace period is configurable via `undoGracePeriod` (in milliseconds).
 
 ## Receipt States
 
-When `outcome` is set, the component renders a compact receipt showing the result. This is useful for displaying the outcome in conversation history.
+Use `<MessageDraftReceipt>` to render a compact receipt showing the result. This is useful for displaying the outcome in conversation history.
 
 <Tabs items={["Sent", "Cancelled"]}>
   <Tab>
     <div className="not-prose mx-auto max-w-sm">
-      <MessageDraft
+      <MessageDraftReceipt
         id="sent-receipt"
         channel="email"
         subject="Interview follow-up"
@@ -173,7 +176,7 @@ When `outcome` is set, the component renders a compact receipt showing the resul
   </Tab>
   <Tab>
     <div className="not-prose mx-auto max-w-sm">
-      <MessageDraft
+      <MessageDraftReceipt
         id="cancelled-receipt"
         channel="slack"
         target={{ type: "channel", name: "general" }}
@@ -237,6 +240,7 @@ pnpm dlx shadcn@latest add button separator
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
   MessageDraft,
+  MessageDraftReceipt,
   MessageDraftErrorBoundary,
   parseSerializableMessageDraft,
   SerializableMessageDraftSchema,
@@ -263,7 +267,7 @@ export const MessageDraftTool = makeAssistantTool<
     return (
       <MessageDraftErrorBoundary>
         {result !== undefined ? (
-          <MessageDraft {...draft} outcome={result} />
+          <MessageDraftReceipt {...draft} outcome={result} />
         ) : (
           <MessageDraft
             {...draft}
@@ -302,10 +306,7 @@ Mount `<MessageDraftTool />` under `<AssistantRuntimeProvider>` to register the 
       type: "string",
       required: true,
     },
-    outcome: {
-      description: "Final state (renders receipt when set)",
-      type: "'sent' | 'cancelled'",
-    },
+    // Receipt rendering uses <MessageDraftReceipt> with a required `outcome`.
     undoGracePeriod: {
       description: "Milliseconds before send is finalized",
       type: "number",

--- a/app/docs/preferences-panel/content.mdx
+++ b/app/docs/preferences-panel/content.mdx
@@ -1,5 +1,8 @@
 import { DocsHeader } from "../_components/docs-header";
-import { PreferencesPanel } from "@/components/tool-ui/preferences-panel";
+import {
+  PreferencesPanel,
+  PreferencesPanelReceipt,
+} from "@/components/tool-ui/preferences-panel";
 
 <DocsHeader
   title="Preferences Panel"
@@ -111,6 +114,92 @@ import { PreferencesPanel } from "@/components/tool-ui/preferences-panel";
   </Feature>
 </FeatureGrid>
 
+## Receipt State
+
+Use `<PreferencesPanelReceipt>` to render the confirmed selections after the user saves. This is ideal for conversation history.
+
+<Tabs items={["Saved", "With Errors"]}>
+  <Tab>
+    <div className="not-prose mx-auto max-w-md">
+      <PreferencesPanelReceipt
+        id="preferences-panel-receipt"
+        title="Privacy Settings"
+        sections={[
+          {
+            heading: "Visibility",
+            items: [
+              {
+                id: "profile-visibility",
+                label: "Profile Visibility",
+                description: "Who can see your profile",
+                type: "toggle",
+                options: [
+                  { value: "public", label: "Public" },
+                  { value: "connections", label: "Friends" },
+                  { value: "private", label: "Private" },
+                ],
+                defaultValue: "connections",
+              },
+              {
+                id: "activity-status",
+                label: "Activity Status",
+                description: "Show when you're active",
+                type: "switch",
+                defaultChecked: true,
+              },
+            ],
+          },
+        ]}
+        choice={{
+          "profile-visibility": "private",
+          "activity-status": false,
+        }}
+      />
+    </div>
+  </Tab>
+  <Tab>
+    <div className="not-prose mx-auto max-w-md">
+      <PreferencesPanelReceipt
+        id="preferences-panel-receipt-errors"
+        title="Privacy Settings"
+        sections={[
+          {
+            heading: "Visibility",
+            items: [
+              {
+                id: "profile-visibility",
+                label: "Profile Visibility",
+                description: "Who can see your profile",
+                type: "toggle",
+                options: [
+                  { value: "public", label: "Public" },
+                  { value: "connections", label: "Friends" },
+                  { value: "private", label: "Private" },
+                ],
+                defaultValue: "connections",
+              },
+              {
+                id: "activity-status",
+                label: "Activity Status",
+                description: "Show when you're active",
+                type: "switch",
+                defaultChecked: true,
+              },
+            ],
+          },
+        ]}
+        choice={{
+          "profile-visibility": "private",
+          "activity-status": false,
+        }}
+        error={{
+          "profile-visibility": "Private profiles require a verified account",
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
 ## Source and Install
 
 Copy [`components/tool-ui/preferences-panel`](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/preferences-panel) and the [`shared`](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/shared) directory into your project. The `shared` folder contains utilities used by all Tool UI components. The `tool-ui` directory should sit alongside your shadcn `ui` directory.
@@ -165,17 +254,26 @@ pnpm dlx shadcn@latest add button label select separator switch toggle-group
 import { makeAssistantTool } from "@assistant-ui/react";
 import {
   PreferencesPanel,
+  PreferencesPanelReceipt,
   PreferencesPanelErrorBoundary,
   parseSerializablePreferencesPanel,
   SerializablePreferencesPanelSchema,
   type SerializablePreferencesPanel,
+  type PreferencesValue,
 } from "@/components/tool-ui/preferences-panel";
 
-export const PreferencesPanelTool = makeAssistantTool<SerializablePreferencesPanel>({
+type PreferencesPanelResult =
+  | { status: "saved"; values: PreferencesValue }
+  | { status: "cancelled" };
+
+export const PreferencesPanelTool = makeAssistantTool<
+  SerializablePreferencesPanel,
+  PreferencesPanelResult
+>({
   toolName: "show_preferences_panel",
   description: "Display user preference settings with staged changes",
   parameters: SerializablePreferencesPanelSchema,
-  render: ({ args, addResult, toolCallId }) => {
+  render: ({ args, addResult, toolCallId, result }) => {
     if (!args.sections) return null;
 
     const data = parseSerializablePreferencesPanel({
@@ -185,15 +283,19 @@ export const PreferencesPanelTool = makeAssistantTool<SerializablePreferencesPan
 
     return (
       <PreferencesPanelErrorBoundary>
-        <PreferencesPanel
-          {...data}
-          onSave={async (values) => {
-            await addResult({ status: "saved", values });
-          }}
-          onCancel={() => {
-            addResult({ status: "cancelled" });
-          }}
-        />
+        {result?.status === "saved" ? (
+          <PreferencesPanelReceipt {...data} choice={result.values} />
+        ) : (
+          <PreferencesPanel
+            {...data}
+            onSave={async (values) => {
+              await addResult({ status: "saved", values });
+            }}
+            onCancel={() => {
+              addResult({ status: "cancelled" });
+            }}
+          />
+        )}
       </PreferencesPanelErrorBoundary>
     );
   },
@@ -226,10 +328,7 @@ export const PreferencesPanelTool = makeAssistantTool<SerializablePreferencesPan
       description: "Called when any preference value changes (before save)",
       type: "(value: PreferencesValue) => void",
     },
-    confirmed: {
-      description: "When provided, renders receipt state showing confirmed preferences with success indicators",
-      type: "PreferencesValue",
-    },
+    // Receipt rendering uses <PreferencesPanelReceipt> with a required `choice`.
     onSave: {
       description: "Handler called when Save button is clicked. Receives current preference values.",
       type: "(value: PreferencesValue) => void | Promise<void>",

--- a/app/docs/receipts/content.mdx
+++ b/app/docs/receipts/content.mdx
@@ -104,13 +104,14 @@ The pattern is: **[Past-tense decision] — [Imperative action]**
 
 Several Tool UI components support receipt states:
 
-| Component | Receipt Prop | What It Shows |
+| Component | Receipt API | What It Shows |
 |-----------|--------------|---------------|
 | [Approval Card](/docs/approval-card) | `choice` | The decision and action title |
 | [Option List](/docs/option-list) | `choice` | Only the selected option(s) |
-| [Preferences Panel](/docs/preferences-panel) | `choice` | Summary of saved preferences |
+| [Preferences Panel](/docs/preferences-panel) | `PreferencesPanelReceipt` | Summary of saved preferences |
 | [Progress Tracker](/docs/progress-tracker) | `choice` | Final status of the workflow |
 | [Order Summary](/docs/order-summary) | `choice` | Confirmed order details |
+| [Message Draft](/docs/message-draft) | `MessageDraftReceipt` | Sent/cancelled outcome |
 
 ## When to Use Receipts
 

--- a/components/tool-ui/message-draft/index.tsx
+++ b/components/tool-ui/message-draft/index.tsx
@@ -1,17 +1,29 @@
-export { MessageDraft, MessageDraftProgress } from "./message-draft";
+export {
+  MessageDraft,
+  MessageDraftReceipt,
+  MessageDraftProgress,
+} from "./message-draft";
 export { MessageDraftErrorBoundary } from "./error-boundary";
 export {
   SerializableMessageDraftSchema,
+  SerializableMessageDraftReceiptSchema,
   SerializableEmailDraftSchema,
+  SerializableEmailDraftReceiptSchema,
   SerializableSlackDraftSchema,
+  SerializableSlackDraftReceiptSchema,
   MessageDraftChannelSchema,
   MessageDraftOutcomeSchema,
   parseSerializableMessageDraft,
+  parseSerializableMessageDraftReceipt,
   type SerializableMessageDraft,
+  type SerializableMessageDraftReceipt,
   type SerializableEmailDraft,
+  type SerializableEmailDraftReceipt,
   type SerializableSlackDraft,
+  type SerializableSlackDraftReceipt,
   type MessageDraftChannel,
   type MessageDraftOutcome,
   type SlackTarget,
   type MessageDraftProps,
+  type MessageDraftReceiptProps,
 } from "./schema";

--- a/components/tool-ui/preferences-panel/index.tsx
+++ b/components/tool-ui/preferences-panel/index.tsx
@@ -1,13 +1,18 @@
 export {
   PreferencesPanel,
+  PreferencesPanelReceipt,
   PreferencesPanelProgress,
 } from "./preferences-panel";
 export { PreferencesPanelErrorBoundary } from "./error-boundary";
 export {
   SerializablePreferencesPanelSchema,
+  SerializablePreferencesPanelReceiptSchema,
   parseSerializablePreferencesPanel,
+  parseSerializablePreferencesPanelReceipt,
   type SerializablePreferencesPanel,
+  type SerializablePreferencesPanelReceipt,
   type PreferencesPanelProps,
+  type PreferencesPanelReceiptProps,
   type PreferencesValue,
   type PreferenceItem,
   type PreferenceSection,

--- a/components/tool-ui/preferences-panel/preferences-panel.tsx
+++ b/components/tool-ui/preferences-panel/preferences-panel.tsx
@@ -6,6 +6,7 @@ import type {
   PreferencesValue,
   PreferenceItem,
   PreferenceSection,
+  PreferencesPanelReceiptProps,
 } from "./schema";
 import { ActionButtons, normalizeActionsConfig } from "../shared";
 import type { Action } from "../shared";
@@ -434,23 +435,14 @@ function ReceiptHeader({ title, hasErrors }: ReceiptHeaderProps) {
   );
 }
 
-interface PreferencesReceiptProps {
-  id: string;
-  title?: string;
-  sections: PreferenceSection[];
-  choice: PreferencesValue;
-  error?: Record<string, string>;
-  className?: string;
-}
-
-function PreferencesReceipt({
+export function PreferencesPanelReceipt({
   id,
   title,
   sections,
   choice,
   error,
   className,
-}: PreferencesReceiptProps) {
+}: PreferencesPanelReceiptProps) {
   const hasErrors = error && Object.keys(error).length > 0;
 
   return (
@@ -488,8 +480,6 @@ export function PreferencesPanel({
   sections,
   value: controlledValue,
   onChange,
-  choice,
-  error,
   onSave,
   onCancel,
   responseActions,
@@ -578,19 +568,6 @@ export function PreferencesPanel({
       };
     });
   }, [normalizedActions.items, isLoading, isDirty]);
-
-  if (choice !== undefined) {
-    return (
-      <PreferencesReceipt
-        id={id}
-        title={title}
-        sections={sections}
-        choice={choice}
-        error={error}
-        className={className}
-      />
-    );
-  }
 
   return (
     <article

--- a/components/tool-ui/preferences-panel/schema.ts
+++ b/components/tool-ui/preferences-panel/schema.ts
@@ -42,14 +42,15 @@ const PreferenceSectionSchema = z.object({
   items: z.array(PreferenceItemSchema).min(1),
 });
 
-export const SerializablePreferencesPanelSchema = z.object({
+const PreferencesPanelBaseSchema = z.object({
   id: ToolUIIdSchema,
   role: ToolUIRoleSchema.optional(),
   receipt: ToolUIReceiptSchema.optional(),
   title: z.string().min(1).optional(),
   sections: z.array(PreferenceSectionSchema).min(1),
-  choice: z.record(z.string(), z.union([z.string(), z.boolean()])).optional(),
-  error: z.record(z.string(), z.string()).optional(),
+});
+
+export const SerializablePreferencesPanelSchema = PreferencesPanelBaseSchema.extend({
   responseActions: z
     .union([
       z.array(SerializableActionSchema),
@@ -62,6 +63,16 @@ export type SerializablePreferencesPanel = z.infer<
   typeof SerializablePreferencesPanelSchema
 >;
 
+export const SerializablePreferencesPanelReceiptSchema =
+  PreferencesPanelBaseSchema.extend({
+    choice: z.record(z.string(), z.union([z.string(), z.boolean()])),
+    error: z.record(z.string(), z.string()).optional(),
+  });
+
+export type SerializablePreferencesPanelReceipt = z.infer<
+  typeof SerializablePreferencesPanelReceiptSchema
+>;
+
 export function parseSerializablePreferencesPanel(
   input: unknown,
 ): SerializablePreferencesPanel {
@@ -69,6 +80,16 @@ export function parseSerializablePreferencesPanel(
     SerializablePreferencesPanelSchema,
     input,
     "PreferencesPanel",
+  );
+}
+
+export function parseSerializablePreferencesPanelReceipt(
+  input: unknown,
+): SerializablePreferencesPanelReceipt {
+  return parseWithSchema(
+    SerializablePreferencesPanelReceiptSchema,
+    input,
+    "PreferencesPanelReceipt",
   );
 }
 
@@ -90,6 +111,11 @@ export interface PreferencesPanelProps
     value: PreferencesValue,
   ) => void | Promise<void>;
   onBeforeResponseAction?: (actionId: string) => boolean | Promise<boolean>;
+}
+
+export interface PreferencesPanelReceiptProps
+  extends SerializablePreferencesPanelReceipt {
+  className?: string;
 }
 
 export type PreferenceItem = z.infer<typeof PreferenceItemSchema>;

--- a/lib/docs/preview-config.tsx
+++ b/lib/docs/preview-config.tsx
@@ -15,13 +15,19 @@ import type { ImageGallery } from "@/components/tool-ui/image-gallery";
 import type { Video } from "@/components/tool-ui/video";
 import type { Audio } from "@/components/tool-ui/audio";
 import type { LinkPreview } from "@/components/tool-ui/link-preview";
-import type { MessageDraft } from "@/components/tool-ui/message-draft";
+import type {
+  MessageDraftProps,
+  MessageDraftReceiptProps,
+} from "@/components/tool-ui/message-draft";
 import type { ItemCarousel } from "@/components/tool-ui/item-carousel";
 import type { OptionList } from "@/components/tool-ui/option-list";
 import type { OrderSummary } from "@/components/tool-ui/order-summary";
 import type { ParameterSlider } from "@/components/tool-ui/parameter-slider";
 import type { Plan } from "@/components/tool-ui/plan";
-import type { PreferencesPanel } from "@/components/tool-ui/preferences-panel";
+import type {
+  PreferencesPanelProps,
+  PreferencesPanelReceiptProps,
+} from "@/components/tool-ui/preferences-panel";
 import type { ProgressTracker } from "@/components/tool-ui/progress-tracker";
 import type { StatsDisplay } from "@/components/tool-ui/stats-display";
 import type { Terminal } from "@/components/tool-ui/terminal";
@@ -140,6 +146,11 @@ const DynamicLinkPreview = dynamic(() =>
 const DynamicMessageDraft = dynamic(() =>
   import("@/components/tool-ui/message-draft").then((m) => m.MessageDraft)
 );
+const DynamicMessageDraftReceipt = dynamic(() =>
+  import("@/components/tool-ui/message-draft").then(
+    (m) => m.MessageDraftReceipt,
+  )
+);
 const DynamicItemCarousel = dynamic(() =>
   import("@/components/tool-ui/item-carousel").then((m) => m.ItemCarousel)
 );
@@ -157,6 +168,11 @@ const DynamicPlan = dynamic(() =>
 );
 const DynamicPreferencesPanel = dynamic(() =>
   import("@/components/tool-ui/preferences-panel").then((m) => m.PreferencesPanel)
+);
+const DynamicPreferencesPanelReceipt = dynamic(() =>
+  import("@/components/tool-ui/preferences-panel").then(
+    (m) => m.PreferencesPanelReceipt,
+  )
 );
 const DynamicProgressTracker = dynamic(() =>
   import("@/components/tool-ui/progress-tracker").then((m) => m.ProgressTracker)
@@ -539,10 +555,13 @@ export const previewConfigs: Record<
       preamble: "I've drafted this message for your review:",
     },
     renderComponent: ({ data }) => {
-      const draftData = data as Parameters<typeof MessageDraft>[0];
+      const draftData = data as MessageDraftProps | MessageDraftReceiptProps;
+      if ("outcome" in draftData) {
+        return <DynamicMessageDraftReceipt {...draftData} />;
+      }
       return (
         <DynamicMessageDraft
-          {...draftData}
+          {...(draftData as MessageDraftProps)}
           onSend={() => console.log("Message sent")}
           onUndo={() => console.log("Send undone")}
           onCancel={() => console.log("Message cancelled")}
@@ -659,10 +678,14 @@ export const previewConfigs: Record<
       preamble: "Here are your current preferences:",
     },
     renderComponent: ({ data, state, setState }) => {
-      const panelData = data as Parameters<typeof PreferencesPanel>[0];
+      const panelData =
+        data as PreferencesPanelProps | PreferencesPanelReceiptProps;
+      if ("choice" in panelData) {
+        return <DynamicPreferencesPanelReceipt {...panelData} />;
+      }
       return (
         <DynamicPreferencesPanel
-          {...panelData}
+          {...(panelData as PreferencesPanelProps)}
           value={
             state.selection as Record<string, string | boolean> | undefined
           }

--- a/lib/presets/message-draft.ts
+++ b/lib/presets/message-draft.ts
@@ -1,4 +1,7 @@
-import type { SerializableMessageDraft } from "@/components/tool-ui/message-draft";
+import type {
+  SerializableMessageDraft,
+  SerializableMessageDraftReceipt,
+} from "@/components/tool-ui/message-draft";
 import type { PresetWithCodeGen } from "./types";
 
 export type MessageDraftPresetName =
@@ -8,7 +11,11 @@ export type MessageDraftPresetName =
   | "slack-dm"
   | "sent";
 
-function generateMessageDraftCode(data: SerializableMessageDraft): string {
+type MessageDraftPresetData =
+  | SerializableMessageDraft
+  | SerializableMessageDraftReceipt;
+
+function generateMessageDraftCode(data: MessageDraftPresetData): string {
   const props: string[] = [];
 
   props.push(`  id="${data.id}"`);
@@ -44,8 +51,9 @@ function generateMessageDraftCode(data: SerializableMessageDraft): string {
 
   props.push(`  body={\`${data.body.replace(/`/g, "\\`")}\`}`);
 
-  if (data.outcome) {
+  if ("outcome" in data) {
     props.push(`  outcome="${data.outcome}"`);
+    return `<MessageDraftReceipt\n${props.join("\n")}\n/>`;
   }
 
   props.push(`  onSend={() => console.log("Message sent")}`);
@@ -56,7 +64,7 @@ function generateMessageDraftCode(data: SerializableMessageDraft): string {
 
 export const messageDraftPresets: Record<
   MessageDraftPresetName,
-  PresetWithCodeGen<SerializableMessageDraft>
+  PresetWithCodeGen<MessageDraftPresetData>
 > = {
   email: {
     description: "Simple email to a single recipient",
@@ -74,7 +82,7 @@ Let me know if you have any questions.
 
 Best,
 Sarah`,
-    },
+    } satisfies SerializableMessageDraft,
     generateExampleCode: generateMessageDraftCode,
   },
   "email-with-cc": {
@@ -100,7 +108,7 @@ Please review and flag any concerns by Friday. We'll finalize allocations next w
 
 Thanks,
 Dana`,
-    },
+    } satisfies SerializableMessageDraft,
     generateExampleCode: generateMessageDraftCode,
   },
   "slack-channel": {
@@ -115,7 +123,7 @@ Dana`,
 - Added keyboard shortcuts for power users
 
 Monitoring dashboards look good. Rollback plan ready if needed.`,
-    },
+    } satisfies SerializableMessageDraft,
     generateExampleCode: generateMessageDraftCode,
   },
   "slack-dm": {
@@ -125,7 +133,7 @@ Monitoring dashboards look good. Rollback plan ready if needed.`,
       channel: "slack",
       target: { type: "dm", name: "Alex Rivera" },
       body: `Hey Alex, just wanted to check in on the API integration. The client asked if we're still on track for the Thursday demo. No pressure if things shifted - just want to give them an accurate update.`,
-    },
+    } satisfies SerializableMessageDraft,
     generateExampleCode: generateMessageDraftCode,
   },
   sent: {
@@ -143,7 +151,7 @@ I'm excited about the opportunity and look forward to hearing from you.
 Best regards,
 Jordan`,
       outcome: "sent",
-    },
+    } satisfies SerializableMessageDraftReceipt,
     generateExampleCode: generateMessageDraftCode,
   },
 };

--- a/lib/presets/preferences-panel.ts
+++ b/lib/presets/preferences-panel.ts
@@ -1,4 +1,7 @@
-import type { SerializablePreferencesPanel } from "@/components/tool-ui/preferences-panel";
+import type {
+  SerializablePreferencesPanel,
+  SerializablePreferencesPanelReceipt,
+} from "@/components/tool-ui/preferences-panel";
 import type { PresetWithCodeGen } from "./types";
 
 export type PreferencesPanelPresetName =
@@ -9,7 +12,13 @@ export type PreferencesPanelPresetName =
   | "receipt"
   | "error";
 
-function generatePreferencesPanelCode(data: SerializablePreferencesPanel): string {
+type PreferencesPanelPresetData =
+  | SerializablePreferencesPanel
+  | SerializablePreferencesPanelReceipt;
+
+function generatePreferencesPanelCode(
+  data: PreferencesPanelPresetData,
+): string {
   const props: string[] = [];
 
   if (data.title) {
@@ -20,10 +29,16 @@ function generatePreferencesPanelCode(data: SerializablePreferencesPanel): strin
     `  sections={${JSON.stringify(data.sections, null, 4).replace(/\n/g, "\n  ")}}`,
   );
 
-  if (data.choice) {
+  if ("choice" in data) {
     props.push(
       `  choice={${JSON.stringify(data.choice, null, 4).replace(/\n/g, "\n  ")}}`,
     );
+    if (data.error) {
+      props.push(
+        `  error={${JSON.stringify(data.error, null, 4).replace(/\n/g, "\n  ")}}`,
+      );
+    }
+    return `<PreferencesPanelReceipt\n${props.join("\n")}\n/>`;
   }
 
   if (data.responseActions) {
@@ -42,7 +57,10 @@ function generatePreferencesPanelCode(data: SerializablePreferencesPanel): strin
   return `<PreferencesPanel\n${props.join("\n")}\n/>`;
 }
 
-export const preferencesPanelPresets: Record<PreferencesPanelPresetName, PresetWithCodeGen<SerializablePreferencesPanel>> = {
+export const preferencesPanelPresets: Record<
+  PreferencesPanelPresetName,
+  PresetWithCodeGen<PreferencesPanelPresetData>
+> = {
   "notifications": {
     description: "Basic notification preferences with switches",
     data: {
@@ -264,7 +282,7 @@ export const preferencesPanelPresets: Record<PreferencesPanelPresetName, PresetW
         "activity-status": false,
         "analytics": false,
       },
-    } satisfies SerializablePreferencesPanel,
+    } satisfies SerializablePreferencesPanelReceipt,
     generateExampleCode: generatePreferencesPanelCode,
   },
   "error": {
@@ -318,7 +336,7 @@ export const preferencesPanelPresets: Record<PreferencesPanelPresetName, PresetW
       error: {
         "analytics": "Analytics requires accepting Terms of Service",
       },
-    } satisfies SerializablePreferencesPanel,
+    } satisfies SerializablePreferencesPanelReceipt,
     generateExampleCode: generatePreferencesPanelCode,
   },
 };


### PR DESCRIPTION
## Summary\n- split PreferencesPanel into interactive + receipt components with new receipt schema\n- split MessageDraft into interactive + receipt components and update presets\n- update docs, preview config, and receipts table to use receipt components\n\n## Testing\n- pnpm typecheck