### PR TITLE
Add explicit loading variants for LinkPreview and ImageGallery

### DIFF
--- a/components/tool-ui/image-gallery/image-gallery.tsx
+++ b/components/tool-ui/image-gallery/image-gallery.tsx
@@ -13,7 +13,6 @@ export function ImageGallery({
   title,
   description,
   className,
-  isLoading,
   onImageClick,
 }: ImageGalleryProps) {
   const handleImageClick = (imageId: string) => {
@@ -28,7 +27,6 @@ export function ImageGallery({
   return (
     <article
       className={cn("relative w-full min-w-80 max-w-lg", className)}
-      aria-busy={isLoading}
       data-tool-ui-id={id}
       data-slot="image-gallery"
     >
@@ -38,23 +36,19 @@ export function ImageGallery({
           "border border-border bg-card text-sm shadow-xs",
         )}
       >
-        {isLoading ? (
-          <LoadingSkeleton />
-        ) : (
-          <ImageGalleryProvider images={images}>
-            <Header title={title} description={description} />
-            <div className="p-3">
-              <GalleryGrid onImageClick={handleImageClick} />
-            </div>
-            <GalleryLightbox />
-          </ImageGalleryProvider>
-        )}
+        <ImageGalleryProvider images={images}>
+          <Header title={title} description={description} />
+          <div className="p-3">
+            <GalleryGrid onImageClick={handleImageClick} />
+          </div>
+          <GalleryLightbox />
+        </ImageGalleryProvider>
       </div>
     </article>
   );
 }
 
-function LoadingSkeleton() {
+export function ImageGalleryProgress() {
   return (
     <div className="flex w-full motion-safe:animate-pulse flex-col gap-3 p-4">
       <div className="grid grid-cols-2 gap-2">

--- a/components/tool-ui/image-gallery/index.tsx
+++ b/components/tool-ui/image-gallery/index.tsx
@@ -1,4 +1,4 @@
-export { ImageGallery } from "./image-gallery";
+export { ImageGallery, ImageGalleryProgress } from "./image-gallery";
 export { ImageGalleryErrorBoundary } from "./error-boundary";
 export type {
   ImageGalleryProps,

--- a/components/tool-ui/image-gallery/schema.ts
+++ b/components/tool-ui/image-gallery/schema.ts
@@ -41,7 +41,6 @@ export type SerializableImageGallery = z.infer<
 
 export interface ImageGalleryProps extends SerializableImageGallery {
   className?: string;
-  isLoading?: boolean;
   onImageClick?: (imageId: string, image: ImageGalleryItem) => void;
 }
 

--- a/components/tool-ui/link-preview/index.ts
+++ b/components/tool-ui/link-preview/index.ts
@@ -1,4 +1,4 @@
-export { LinkPreview } from "./link-preview";
+export { LinkPreview, LinkPreviewProgress } from "./link-preview";
 export type { LinkPreviewProps } from "./link-preview";
 export { LinkPreviewErrorBoundary } from "./error-boundary";
 export { SerializableLinkPreviewSchema, parseSerializableLinkPreview } from "./schema";

--- a/components/tool-ui/link-preview/link-preview.tsx
+++ b/components/tool-ui/link-preview/link-preview.tsx
@@ -11,7 +11,7 @@ import type { SerializableLinkPreview } from "./schema";
 const FALLBACK_LOCALE = "en-US";
 const CONTENT_SPACING = "px-5 py-4 gap-2";
 
-function LinkPreviewProgress() {
+export function LinkPreviewProgress() {
   return (
     <div className="flex w-full motion-safe:animate-pulse flex-col">
       <div className="bg-muted aspect-[5/3] w-full" />
@@ -29,7 +29,6 @@ function LinkPreviewProgress() {
 
 export interface LinkPreviewProps extends SerializableLinkPreview {
   className?: string;
-  isLoading?: boolean;
   onNavigate?: (href: string, preview: SerializableLinkPreview) => void;
   responseActions?: ActionsProp;
   onResponseAction?: (actionId: string) => void | Promise<void>;
@@ -39,7 +38,6 @@ export interface LinkPreviewProps extends SerializableLinkPreview {
 export function LinkPreview(props: LinkPreviewProps) {
   const {
     className,
-    isLoading,
     onNavigate,
     responseActions,
     onResponseAction,
@@ -87,7 +85,6 @@ export function LinkPreview(props: LinkPreviewProps) {
     <article
       className={cn("relative w-full min-w-80 max-w-md", className)}
       lang={locale}
-      aria-busy={isLoading}
       data-tool-ui-id={id}
       data-slot="link-preview"
     >
@@ -111,65 +108,61 @@ export function LinkPreview(props: LinkPreviewProps) {
             : undefined
         }
       >
-        {isLoading ? (
-          <LinkPreviewProgress />
-        ) : (
-          <div className="flex flex-col">
-            {image && (
-              <div
+        <div className="flex flex-col">
+          {image && (
+            <div
+              className={cn(
+                "bg-muted relative w-full overflow-hidden",
+                ratio !== "auto" ? RATIO_CLASS_MAP[ratio] : "aspect-[5/3]",
+              )}
+            >
+              <img
+                src={image}
+                alt=""
+                loading="lazy"
+                decoding="async"
                 className={cn(
-                  "bg-muted relative w-full overflow-hidden",
-                  ratio !== "auto" ? RATIO_CLASS_MAP[ratio] : "aspect-[5/3]",
+                  "absolute inset-0 h-full w-full",
+                  getFitClass(fit),
+                  "object-center transition-transform duration-200 group-hover:scale-[1.01]",
                 )}
-              >
-                <img
-                  src={image}
-                  alt=""
-                  loading="lazy"
-                  decoding="async"
-                  className={cn(
-                    "absolute inset-0 h-full w-full",
-                    getFitClass(fit),
-                    "object-center transition-transform duration-200 group-hover:scale-[1.01]",
-                  )}
-                />
+              />
+            </div>
+          )}
+          <div className={cn("flex flex-col", CONTENT_SPACING)}>
+            {domain && (
+              <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                {favicon ? (
+                  <img
+                    src={favicon}
+                    alt=""
+                    aria-hidden="true"
+                    width={16}
+                    height={16}
+                    className="size-4 rounded-full object-cover"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                ) : (
+                  <div className="border-border/60 bg-muted flex size-4 shrink-0 items-center justify-center rounded-full border">
+                    <Globe className="h-2.5 w-2.5" aria-hidden="true" />
+                  </div>
+                )}
+                <span>{domain}</span>
               </div>
             )}
-            <div className={cn("flex flex-col", CONTENT_SPACING)}>
-              {domain && (
-                <div className="text-muted-foreground flex items-center gap-2 text-xs">
-                  {favicon ? (
-                    <img
-                      src={favicon}
-                      alt=""
-                      aria-hidden="true"
-                      width={16}
-                      height={16}
-                      className="size-4 rounded-full object-cover"
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  ) : (
-                    <div className="border-border/60 bg-muted flex size-4 shrink-0 items-center justify-center rounded-full border">
-                      <Globe className="h-2.5 w-2.5" aria-hidden="true" />
-                    </div>
-                  )}
-                  <span>{domain}</span>
-                </div>
-              )}
-              {title && (
-                <h3 className="text-foreground text-pretty text-base font-medium">
-                  <span className="line-clamp-2">{title}</span>
-                </h3>
-              )}
-              {description && (
-                <p className="text-muted-foreground text-pretty leading-snug">
-                  <span className="line-clamp-2">{description}</span>
-                </p>
-              )}
-            </div>
+            {title && (
+              <h3 className="text-foreground text-pretty text-base font-medium">
+                <span className="line-clamp-2">{title}</span>
+              </h3>
+            )}
+            {description && (
+              <p className="text-muted-foreground text-pretty leading-snug">
+                <span className="line-clamp-2">{description}</span>
+              </p>
+            )}
           </div>
-        )}
+        </div>
       </div>
       {normalizedActions && (
         <div className="@container/actions mt-3">


### PR DESCRIPTION
## Summary\n- export LinkPreviewProgress and remove isLoading prop from LinkPreview\n- export ImageGalleryProgress and remove isLoading prop from ImageGallery\n- keep loading skeletons as explicit components instead of boolean toggles\n\n## Testing\n- pnpm typecheck