### PR TITLE
Refactor DataTable variants

### DIFF
--- a/app/components/home/chat-showcase.tsx
+++ b/app/components/home/chat-showcase.tsx
@@ -561,12 +561,11 @@ function createSceneConfigs(reducedMotion: boolean): SceneConfig[] {
       userMessage: "Find me flights to Tokyo in March",
       preamble: "Found 4 nonstop flights. Sorted by price.",
       toolUI: (
-        <DataTable<Flight>
+        <DataTable.Table<Flight>
           id="chat-showcase-data-table"
           rowIdKey="id"
           columns={TABLE_COLUMNS}
           data={TABLE_DATA}
-          layout="table"
           defaultSort={{ by: "price", direction: "asc" }}
         />
       ),

--- a/app/docs/data-table/content.mdx
+++ b/app/docs/data-table/content.mdx
@@ -178,6 +178,18 @@ import {
   </Feature>
 </FeatureGrid>
 
+## Layout Variants
+
+Use explicit components when you want to force a layout:
+
+- `<DataTable>` (default): responsive auto layout
+- `<DataTable.Table>`: always render the table view
+- `<DataTable.Cards>`: always render the card view
+
+```tsx
+import { DataTable } from "@/components/tool-ui/data-table";
+```
+
 ## Source and Install
 
 Copy [`components/tool-ui/data-table`](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/data-table) and the [`shared`](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/shared) directory into your project. The `shared` folder contains utilities used by all Tool UI components. The `tool-ui` directory should sit alongside your shadcn `ui` directory.

--- a/app/docs/data-table/tasks-demo.tsx
+++ b/app/docs/data-table/tasks-demo.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { Column, DataTable, DataTableRowData } from "@/components/tool-ui/data-table";
+import {
+  Column,
+  DataTable,
+  DataTableRowData,
+} from "@/components/tool-ui/data-table";
 import { getMockTasks } from "@/lib/mocks/tasks";
 import { useEffect, useState } from "react";
 
@@ -70,13 +74,12 @@ export function TasksDemo() {
 
   return (
     <div className="not-prose">
-      <DataTable
+      <DataTable.Table
         id="data-table-tasks-demo"
         rowIdKey="id"
         columns={columns}
         data={rows ?? []}
         defaultSort={{ by: "urgencyOrder", direction: "asc" }}
-        layout="table"
       />
     </div>
   );

--- a/components/tool-ui/data-table/schema.ts
+++ b/components/tool-ui/data-table/schema.ts
@@ -9,7 +9,6 @@ import type { Column, DataTableProps, RowData } from "./types";
 
 const AlignEnum = z.enum(["left", "right", "center"]);
 const PriorityEnum = z.enum(["primary", "secondary", "tertiary"]);
-const LayoutEnum = z.enum(["auto", "table", "cards"]);
 
 const formatSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("text") }),
@@ -152,7 +151,6 @@ export const SerializableDataTableSchema = z.object({
   receipt: ToolUIReceiptSchema.optional(),
   columns: z.array(serializableColumnSchema),
   data: z.array(serializableDataSchema),
-  layout: LayoutEnum.optional(),
 });
 
 /**
@@ -216,9 +214,9 @@ export function parseSerializableDataTable(
   input: unknown,
 ): Pick<
   DataTableProps<RowData>,
-  "id" | "role" | "receipt" | "columns" | "data" | "layout"
+  "id" | "role" | "receipt" | "columns" | "data"
 > {
-  const { id, role, receipt, columns, data, layout } = parseWithSchema(
+  const { id, role, receipt, columns, data } = parseWithSchema(
     SerializableDataTableSchema,
     input,
     "DataTable",
@@ -229,6 +227,5 @@ export function parseSerializableDataTable(
     receipt,
     columns: columns as unknown as Column<RowData>[],
     data: data as RowData[],
-    layout,
   };
 }

--- a/components/tool-ui/data-table/types.ts
+++ b/components/tool-ui/data-table/types.ts
@@ -127,13 +127,6 @@ export interface DataTableSerializableProps<T extends object = RowData> {
   /** Row data (primitives only - no functions or class instances) */
   data: T[];
   /**
-   * Layout mode for the component.
-   * - 'auto' (default): Container queries choose table/cards
-   * - 'table': Force table layout
-   * - 'cards': Force stacked card layout
-   */
-  layout?: "auto" | "table" | "cards";
-  /**
    * Key in row data to use as unique identifier for React keys
    *
    * **Strongly recommended:** Always provide this for dynamic data to prevent


### PR DESCRIPTION
## Summary
- move DataTable layout variants into dot-style API (, )
- introduce explicit  with internal context wiring
- update docs and usage sites to the new variant API

## Testing
- pnpm typecheck