### PR TITLE
docs: make payload-gating rule explicit for Tool UI renderers

### DIFF
--- a/.claude/agents/tool-ui-documenter.md
+++ b/.claude/agents/tool-ui-documenter.md
@@ -174,7 +174,7 @@ import { makeAssistantTool } from "@assistant-ui/react";
 import {
   {Name},
   {Name}ErrorBoundary,
-  parseSerializable{Name},
+  safeParseSerializable{Name},
   Serializable{Name}Schema,
   type Serializable{Name},
 } from "@/components/tool-ui/{name}";
@@ -184,13 +184,13 @@ export const {Name}Tool = makeAssistantTool<Serializable{Name}>({
   description: "{Tool description}",
   parameters: Serializable{Name}Schema,
   render: ({ args, result, addResult, toolCallId }) => {
-    // Wait for required fields during streaming
-    if (!{streaming check}) return null;
-
-    const data = parseSerializable{Name}({
+    const data = safeParseSerializable{Name}({
       ...args,
       id: (args as any)?.id ?? `{name}-${toolCallId}`,
     });
+
+    // Tool UI renderers should mount only when the full payload parses.
+    if (!data) return null;
 
     return (
       <{Name}ErrorBoundary>

--- a/app/docs/advanced/content.mdx
+++ b/app/docs/advanced/content.mdx
@@ -132,11 +132,19 @@ For a single tool, `InferUITool` works the same way as `InferUITools` but for on
 
 Use the component's `outputSchema` on the server and `safeParseSerializable{componentName}` on the client to validate at both ends.
 
-### Lifecycle-aware rendering
+### Lifecycle-aware routing (outside Tool UI renderers)
 
-Use `part.state` to respect the Tool UI lifecycle from UI Guidelines:
+If you consume raw `message.parts`, keep lifecycle handling outside Tool UI components:
 
-- `state === 'invocation'` → show intent / shell
-- `state === 'output-pending'` → show skeleton / loading shell
-- `state === 'output-available'` → render the full component
-- `state === 'errored'` → show an error surface instead of silently failing
+- `state === 'invocation'` / `state === 'output-pending'` / `state === 'errored'`:
+  route to app-level UI (message shell, transport error, telemetry), not the Tool UI component.
+- `state === 'output-available'`:
+  parse `part.output` with `safeParseSerializable{componentName}` and render only when parsing succeeds.
+
+Inside Tool UI toolkit renderers, use a strict gate:
+
+```tsx
+const parsed = safeParseSerializableX(resultOrArgs);
+if (!parsed) return null;
+return <X {...parsed} />;
+```

--- a/app/docs/contributing/content.mdx
+++ b/app/docs/contributing/content.mdx
@@ -62,6 +62,8 @@ Before coding:
 Implementation pattern:
 
 1. `schema.ts`: Define `SerializableXSchema`, `parseSerializableX(input: unknown)`, and `safeParseSerializableX(input: unknown)`
+   - In toolkit `render` snippets, always gate with `safeParseSerializableX(...)`; if parsing fails, `return null`.
+   - Do not branch on transport/runtime lifecycle state (`status`, `state.kind`, etc.) inside Tool UI renderers.
 2. `types.ts`: Create:
    - Serializable props type (derived from the schema)
    - Client props type (serializable props + callbacks like `onAction`, `onBeforeAction`)

--- a/app/docs/overview/content.mdx
+++ b/app/docs/overview/content.mdx
@@ -125,7 +125,7 @@ export async function POST(req: Request) {
 **What this demonstrates:**
 
 - `Tools({ toolkit })` registers tool renderers once
-- `safeParseSerializableLinkPreview` validates streamed tool output safely
+- `safeParseSerializableLinkPreview` is the render gate: return `null` until the full payload parses
 - `useAui({ tools: ... })` makes tool UIs available to the runtime
 - assistant-ui manages the runtime, streaming, and tool call lifecycle
 
@@ -152,6 +152,7 @@ const toolkit: Toolkit = {
     render: ({ result }) => {
       const parsedResult = safeParseSerializableLinkPreview(result);
 
+      // Tool UI renderers should mount only when the full payload parses.
       if (!parsedResult) {
         return null;
       }

--- a/app/docs/quick-start/content.mdx
+++ b/app/docs/quick-start/content.mdx
@@ -51,7 +51,7 @@ Create a tool on your server that the LLM can call. The tool returns structured 
 
 - `SerializableLinkPreviewSchema` ensures your tool output matches the LinkPreview component's expected format
 - `id` identifies this rendering in the conversation
-- `safeParseSerializableLinkPreview` on the frontend validates streamed results before rendering
+- `safeParseSerializableLinkPreview` on the frontend gates rendering until the payload is complete
 - Your tool can fetch real data (APIs, databases) and return it in the component schema format
 
 ```ts
@@ -100,7 +100,7 @@ Connect your backend tool to a frontend component. When the LLM calls the `previ
 **What this demonstrates:**
 
 - `Tools({ toolkit })` registers tool renderers in one place
-- `safeParseSerializableLinkPreview` keeps rendering safe while tool payloads stream
+- `safeParseSerializableLinkPreview` is the render gate: no payload, no render (`return null`)
 - The toolkit key (`previewLink`) must match your backend tool name
 - `useAui({ tools: ... })` wires tool rendering into `AssistantRuntimeProvider`
 
@@ -127,6 +127,7 @@ const toolkit: Toolkit = {
     render: ({ result }) => {
       const parsedResult = safeParseSerializableLinkPreview(result);
 
+      // Tool UI renderers should mount only when the full payload parses.
       if (!parsedResult) {
         return null;
       }
@@ -259,6 +260,7 @@ export const toolkit: Toolkit = {
       id: (args as any)?.id ?? `format-selection-${toolCallId}`,
     });
 
+    // Tool UI renderers should mount only when the full payload parses.
     if (!parsedArgs) {
       return null;
     }


### PR DESCRIPTION
## Summary
- clarified the public docs invariant that Tool UI renderers must gate on `safeParse...` and return `null` until payload parsing succeeds
- updated advanced docs to route transport lifecycle states outside Tool UI renderers
- updated contributing and internal doc-template guidance to avoid `status`/lifecycle branching inside toolkit render snippets

## Files
- .claude/agents/tool-ui-documenter.md
- app/docs/advanced/content.mdx
- app/docs/contributing/content.mdx
- app/docs/overview/content.mdx
- app/docs/quick-start/content.mdx

## Validation
- targeted grep confirmed deprecated guidance phrases were removed
- targeted grep confirmed new `safeParse -> return null` guidance is present in updated docs