### PR TITLE
refactor: remove shared barrel imports across all tool-ui components

### DIFF
--- a/components/tool-ui/approval-card/approval-card.tsx
+++ b/components/tool-ui/approval-card/approval-card.tsx
@@ -2,9 +2,9 @@
 
 import * as React from "react";
 import { cn, Separator } from "./_adapter";
-import type { ApprovalCardProps, ApprovalDecision } from "./schema";
-import { ActionButtons } from "../shared";
-import type { Action } from "../shared";
+import type { ApprovalCardProps, ApprovalDecision } from "./schema";import { ActionButtons } from "../shared/action-buttons";
+import { type Action } from "../shared/schema";
+
 import { icons, Check, X } from "lucide-react";
 
 type LucideIcon = React.ComponentType<{ className?: string }>;

--- a/components/tool-ui/approval-card/error-boundary.tsx
+++ b/components/tool-ui/approval-card/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const ApprovalCardErrorBoundary =
   createToolUiErrorBoundary("ApprovalCard");

--- a/components/tool-ui/approval-card/schema.ts
+++ b/components/tool-ui/approval-card/schema.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { ToolUIIdSchema, ToolUIRoleSchema } from "../shared/schema";
-import { defineToolUiContract } from "../shared";
+import { ToolUIIdSchema, ToolUIRoleSchema } from "../shared/schema";import { defineToolUiContract } from "../shared/contract";
 
 export const MetadataItemSchema = z.object({
   key: z.string().min(1),

--- a/components/tool-ui/audio/audio.tsx
+++ b/components/tool-ui/audio/audio.tsx
@@ -3,8 +3,9 @@
 
 import * as React from "react";
 import { Pause, Play } from "lucide-react";
-import { cn, Button, Slider } from "./_adapter";
-import { ActionButtons, normalizeActionsConfig, type ActionsProp } from "../shared";
+import { cn, Button, Slider } from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+
 import { AudioProvider, useAudio } from "./context";
 import type { SerializableAudio, AudioVariant } from "./schema";
 

--- a/components/tool-ui/audio/error-boundary.tsx
+++ b/components/tool-ui/audio/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const AudioErrorBoundary = createToolUiErrorBoundary("Audio");

--- a/components/tool-ui/audio/schema.ts
+++ b/components/tool-ui/audio/schema.ts
@@ -1,10 +1,5 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const SourceSchema = z.object({
   label: z.string(),

--- a/components/tool-ui/chart/error-boundary.tsx
+++ b/components/tool-ui/chart/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const ChartErrorBoundary = createToolUiErrorBoundary("Chart");

--- a/components/tool-ui/chart/schema.ts
+++ b/components/tool-ui/chart/schema.ts
@@ -1,10 +1,5 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const ChartSeriesSchema = z.object({
   key: z.string().min(1),

--- a/components/tool-ui/citation/citation.tsx
+++ b/components/tool-ui/citation/citation.tsx
@@ -12,12 +12,9 @@ import {
   File,
   ExternalLink,
 } from "lucide-react";
-import { cn, Popover, PopoverContent, PopoverTrigger } from "./_adapter";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  type ActionsProp,
-} from "../shared";
+import { cn, Popover, PopoverContent, PopoverTrigger } from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+
 import { openSafeNavigationHref, sanitizeHref } from "../shared/media";
 import type {
   SerializableCitation,

--- a/components/tool-ui/citation/error-boundary.tsx
+++ b/components/tool-ui/citation/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const CitationErrorBoundary = createToolUiErrorBoundary("Citation");

--- a/components/tool-ui/citation/schema.ts
+++ b/components/tool-ui/citation/schema.ts
@@ -1,10 +1,5 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const CitationTypeSchema = z.enum([
   "webpage",

--- a/components/tool-ui/code-block/code-block.tsx
+++ b/components/tool-ui/code-block/code-block.tsx
@@ -3,12 +3,10 @@
 import { useMemo, useState, useCallback, useEffect } from "react";
 import { createHighlighter, type Highlighter } from "shiki";
 import { Copy, Check, ChevronDown, ChevronUp } from "lucide-react";
-import type { CodeBlockProps } from "./schema";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  useCopyToClipboard,
-} from "../shared";
+import type { CodeBlockProps } from "./schema";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig } from "../shared/actions-config";
+import { useCopyToClipboard } from "../shared/use-copy-to-clipboard";
+
 import { Button, cn, Collapsible, CollapsibleTrigger } from "./_adapter";
 const COPY_ID = "codeblock-code";
 

--- a/components/tool-ui/code-block/error-boundary.tsx
+++ b/components/tool-ui/code-block/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const CodeBlockErrorBoundary = createToolUiErrorBoundary("CodeBlock");

--- a/components/tool-ui/code-block/schema.ts
+++ b/components/tool-ui/code-block/schema.ts
@@ -1,12 +1,5 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  SerializableActionSchema,
-  SerializableActionsConfigSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { SerializableActionSchema, SerializableActionsConfigSchema, ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const CodeBlockPropsSchema = z.object({
   id: ToolUIIdSchema,

--- a/components/tool-ui/image-gallery/error-boundary.tsx
+++ b/components/tool-ui/image-gallery/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const ImageGalleryErrorBoundary =
   createToolUiErrorBoundary("ImageGallery");

--- a/components/tool-ui/image-gallery/schema.ts
+++ b/components/tool-ui/image-gallery/schema.ts
@@ -1,10 +1,5 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const ImageGallerySourceSchema = z.object({
   label: z.string(),

--- a/components/tool-ui/image/error-boundary.tsx
+++ b/components/tool-ui/image/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const ImageErrorBoundary = createToolUiErrorBoundary("Image");

--- a/components/tool-ui/image/image.tsx
+++ b/components/tool-ui/image/image.tsx
@@ -2,12 +2,9 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "./_adapter";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  type ActionsProp,
-} from "../shared";
+import { cn } from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+
 import {
   RATIO_CLASS_MAP,
   getFitClass,

--- a/components/tool-ui/image/schema.ts
+++ b/components/tool-ui/image/schema.ts
@@ -1,10 +1,6 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
+
 import { AspectRatioSchema, MediaFitSchema } from "../shared/media";
 
 export const SourceSchema = z.object({

--- a/components/tool-ui/instagram-post/error-boundary.tsx
+++ b/components/tool-ui/instagram-post/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const InstagramPostErrorBoundary =
   createToolUiErrorBoundary("InstagramPost");

--- a/components/tool-ui/instagram-post/instagram-post.tsx
+++ b/components/tool-ui/instagram-post/instagram-post.tsx
@@ -9,13 +9,10 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./_adapter";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  type ActionsProp,
-  formatRelativeTime,
-} from "../shared";
+} from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+import { formatRelativeTime } from "../shared/utils";
+
 import type { InstagramPostData, InstagramPostMedia } from "./schema";
 
 export interface InstagramPostProps {

--- a/components/tool-ui/instagram-post/schema.ts
+++ b/components/tool-ui/instagram-post/schema.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-import { defineToolUiContract } from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
 
 export const InstagramPostAuthorSchema = z.object({
   name: z.string(),

--- a/components/tool-ui/item-carousel/schema.ts
+++ b/components/tool-ui/item-carousel/schema.ts
@@ -1,10 +1,5 @@
-import { z } from "zod";
-import {
-  ActionSchema,
-  defineToolUiContract,
-  SerializableActionSchema,
-  ToolUIIdSchema,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ActionSchema, SerializableActionSchema, ToolUIIdSchema } from "../shared/schema";
 
 export const ItemSchema = z.object({
   id: z.string().min(1),

--- a/components/tool-ui/link-preview/error-boundary.tsx
+++ b/components/tool-ui/link-preview/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const LinkPreviewErrorBoundary =
   createToolUiErrorBoundary("LinkPreview");

--- a/components/tool-ui/link-preview/link-preview.tsx
+++ b/components/tool-ui/link-preview/link-preview.tsx
@@ -3,12 +3,9 @@
 
 import * as React from "react";
 import { Globe } from "lucide-react";
-import { cn } from "./_adapter";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  type ActionsProp,
-} from "../shared";
+import { cn } from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+
 import {
   RATIO_CLASS_MAP,
   getFitClass,

--- a/components/tool-ui/link-preview/schema.ts
+++ b/components/tool-ui/link-preview/schema.ts
@@ -1,10 +1,6 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
+
 import { AspectRatioSchema, MediaFitSchema } from "../shared/media";
 
 export const SerializableLinkPreviewSchema = z.object({

--- a/components/tool-ui/linkedin-post/error-boundary.tsx
+++ b/components/tool-ui/linkedin-post/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const LinkedInPostErrorBoundary =
   createToolUiErrorBoundary("LinkedInPost");

--- a/components/tool-ui/linkedin-post/linkedin-post.tsx
+++ b/components/tool-ui/linkedin-post/linkedin-post.tsx
@@ -9,15 +9,10 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./_adapter";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  type ActionsProp,
-  formatRelativeTime,
-  formatCount,
-  getDomain,
-} from "../shared";
+} from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+import { formatCount, formatRelativeTime, getDomain } from "../shared/utils";
+
 import { resolveSafeNavigationHref } from "../shared/media";
 import type {
   LinkedInPostData,

--- a/components/tool-ui/linkedin-post/schema.ts
+++ b/components/tool-ui/linkedin-post/schema.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-import { defineToolUiContract } from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
 
 export const LinkedInPostAuthorSchema = z.object({
   name: z.string(),

--- a/components/tool-ui/order-summary/error-boundary.tsx
+++ b/components/tool-ui/order-summary/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const OrderSummaryErrorBoundary =
   createToolUiErrorBoundary("OrderSummary");

--- a/components/tool-ui/order-summary/order-summary.tsx
+++ b/components/tool-ui/order-summary/order-summary.tsx
@@ -4,8 +4,7 @@ import * as React from "react";
 import { useCallback } from "react";
 import { CheckCircle, Package } from "lucide-react";
 import { cn, Separator } from "./_adapter";
-import type { OrderSummaryProps, OrderItem, Pricing } from "./schema";
-import { ActionButtons } from "../shared";
+import type { OrderSummaryProps, OrderItem, Pricing } from "./schema";import { ActionButtons } from "../shared/action-buttons";
 
 const defaultActions = [
   { id: "cancel", label: "Cancel", variant: "outline" as const },

--- a/components/tool-ui/order-summary/schema.ts
+++ b/components/tool-ui/order-summary/schema.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { ToolUIIdSchema, ToolUIRoleSchema } from "../shared/schema";
-import { defineToolUiContract } from "../shared";
+import { ToolUIIdSchema, ToolUIRoleSchema } from "../shared/schema";import { defineToolUiContract } from "../shared/contract";
 
 export const OrderItemSchema = z.object({
   id: z.string(),

--- a/components/tool-ui/parameter-slider/error-boundary.tsx
+++ b/components/tool-ui/parameter-slider/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const ParameterSliderErrorBoundary =
   createToolUiErrorBoundary("ParameterSlider");

--- a/components/tool-ui/parameter-slider/parameter-slider.tsx
+++ b/components/tool-ui/parameter-slider/parameter-slider.tsx
@@ -9,13 +9,11 @@ import {
   useState,
 } from "react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
-import type { ParameterSliderProps, SliderConfig, SliderValue } from "./schema";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  useControllableState,
-  useSignatureReset,
-} from "../shared";
+import type { ParameterSliderProps, SliderConfig, SliderValue } from "./schema";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig } from "../shared/actions-config";
+import { useControllableState } from "../shared/use-controllable-state";
+import { useSignatureReset } from "../shared/use-signature-reset";
+
 import { cn } from "./_adapter";
 import {
   createSliderSignature,

--- a/components/tool-ui/parameter-slider/schema.ts
+++ b/components/tool-ui/parameter-slider/schema.ts
@@ -1,12 +1,6 @@
-import { z } from "zod";
-import type { ActionsProp } from "../shared";
-import {
-  ToolUIIdSchema,
-  ToolUIRoleSchema,
-  SerializableActionSchema,
-  SerializableActionsConfigSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { type ActionsProp } from "../shared/actions-config";
+import { defineToolUiContract } from "../shared/contract";
+import { SerializableActionSchema, SerializableActionsConfigSchema, ToolUIIdSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const SliderConfigSchema = z.object({
   id: z.string().min(1),

--- a/components/tool-ui/preferences-panel/error-boundary.tsx
+++ b/components/tool-ui/preferences-panel/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const PreferencesPanelErrorBoundary =
   createToolUiErrorBoundary("PreferencesPanel");

--- a/components/tool-ui/preferences-panel/preferences-panel.tsx
+++ b/components/tool-ui/preferences-panel/preferences-panel.tsx
@@ -7,14 +7,12 @@ import type {
   PreferencesValue,
   PreferenceItem,
   PreferenceSection,
-} from "./schema";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  useControllableState,
-  useSignatureReset,
-} from "../shared";
-import type { Action } from "../shared";
+} from "./schema";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig } from "../shared/actions-config";
+import { type Action } from "../shared/schema";
+import { useControllableState } from "../shared/use-controllable-state";
+import { useSignatureReset } from "../shared/use-signature-reset";
+
 import {
   cn,
   Switch,

--- a/components/tool-ui/preferences-panel/schema.ts
+++ b/components/tool-ui/preferences-panel/schema.ts
@@ -1,13 +1,6 @@
-import { z } from "zod";
-import type { ActionsProp } from "../shared";
-import {
-  SerializableActionSchema,
-  SerializableActionsConfigSchema,
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { type ActionsProp } from "../shared/actions-config";
+import { defineToolUiContract } from "../shared/contract";
+import { SerializableActionSchema, SerializableActionsConfigSchema, ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
 
 const PreferenceItemBaseSchema = z.object({
   id: z.string().min(1),

--- a/components/tool-ui/question-flow/error-boundary.tsx
+++ b/components/tool-ui/question-flow/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const QuestionFlowErrorBoundary =
   createToolUiErrorBoundary("QuestionFlow");

--- a/components/tool-ui/question-flow/schema.ts
+++ b/components/tool-ui/question-flow/schema.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
-import type { ReactNode } from "react";
-import {
-  ToolUIIdSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import type { ReactNode } from "react";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const QuestionFlowOptionSchema = z.object({
   id: z.string().min(1),

--- a/components/tool-ui/stats-display/error-boundary.tsx
+++ b/components/tool-ui/stats-display/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const StatsDisplayErrorBoundary =
   createToolUiErrorBoundary("StatsDisplay");

--- a/components/tool-ui/stats-display/schema.ts
+++ b/components/tool-ui/stats-display/schema.ts
@@ -1,9 +1,5 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIRoleSchema } from "../shared/schema";
 
 const TextFormatSchema = z.object({
   kind: z.literal("text"),

--- a/components/tool-ui/terminal/error-boundary.tsx
+++ b/components/tool-ui/terminal/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const TerminalErrorBoundary = createToolUiErrorBoundary("Terminal");

--- a/components/tool-ui/terminal/schema.ts
+++ b/components/tool-ui/terminal/schema.ts
@@ -1,12 +1,5 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  SerializableActionSchema,
-  SerializableActionsConfigSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { SerializableActionSchema, SerializableActionsConfigSchema, ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
 
 export const TerminalPropsSchema = z.object({
   id: ToolUIIdSchema,

--- a/components/tool-ui/terminal/terminal.tsx
+++ b/components/tool-ui/terminal/terminal.tsx
@@ -9,12 +9,10 @@ import {
   ChevronUp,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import type { TerminalProps } from "./schema";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  useCopyToClipboard,
-} from "../shared";
+import type { TerminalProps } from "./schema";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig } from "../shared/actions-config";
+import { useCopyToClipboard } from "../shared/use-copy-to-clipboard";
+
 import { Button, Collapsible, CollapsibleTrigger } from "./_adapter";
 import { cn } from "./_adapter";
 

--- a/components/tool-ui/video/error-boundary.tsx
+++ b/components/tool-ui/video/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const VideoErrorBoundary = createToolUiErrorBoundary("Video");

--- a/components/tool-ui/video/schema.ts
+++ b/components/tool-ui/video/schema.ts
@@ -1,10 +1,6 @@
-import { z } from "zod";
-import {
-  ToolUIIdSchema,
-  ToolUIReceiptSchema,
-  ToolUIRoleSchema,
-  defineToolUiContract,
-} from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+import { ToolUIIdSchema, ToolUIReceiptSchema, ToolUIRoleSchema } from "../shared/schema";
+
 import { AspectRatioSchema, MediaFitSchema } from "../shared/media";
 
 export const SourceSchema = z.object({

--- a/components/tool-ui/video/video.tsx
+++ b/components/tool-ui/video/video.tsx
@@ -2,8 +2,9 @@
 
 import * as React from "react";
 import { Play } from "lucide-react";
-import { cn, Button } from "./_adapter";
-import { ActionButtons, normalizeActionsConfig, type ActionsProp } from "../shared";
+import { cn, Button } from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+
 import {
   RATIO_CLASS_MAP,
   OVERLAY_GRADIENT,

--- a/components/tool-ui/weather-widget/effects/canvas-resolver.ts
+++ b/components/tool-ui/weather-widget/effects/canvas-resolver.ts
@@ -1,11 +1,9 @@
-import type { WeatherConditionCode } from "../schema";
 import type { WeatherEffectParams } from "./types";
 import {
   buildCanvasBaseFromWeather,
   createStudioTimestamp,
 } from "./canvas-resolver-base";
 import {
-  resolveConditionCheckpointOverridesForTime,
   resolveInterpolatedOverridesForTime,
 } from "./checkpoint-overrides";
 import {

--- a/components/tool-ui/weather-widget/error-boundary.tsx
+++ b/components/tool-ui/weather-widget/error-boundary.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const WeatherWidgetErrorBoundary =
   createToolUiErrorBoundary("WeatherWidget");

--- a/components/tool-ui/weather-widget/schema.ts
+++ b/components/tool-ui/weather-widget/schema.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
-import { defineToolUiContract } from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
+
 import type { CustomEffectProps } from "./effects/custom-effect-props";
 import type { EffectSettings } from "./effects/types";
 

--- a/components/tool-ui/x-post/error-boundary.tsx
+++ b/components/tool-ui/x-post/error-boundary.tsx
@@ -1,5 +1,3 @@
-"use client";
-
-import { createToolUiErrorBoundary } from "../shared";
+"use client";import { createToolUiErrorBoundary } from "../shared/error-boundary";
 
 export const XPostErrorBoundary = createToolUiErrorBoundary("XPost");

--- a/components/tool-ui/x-post/schema.ts
+++ b/components/tool-ui/x-post/schema.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-import { defineToolUiContract } from "../shared";
+import { z } from "zod";import { defineToolUiContract } from "../shared/contract";
 
 export const XPostAuthorSchema = z.object({
   name: z.string(),

--- a/components/tool-ui/x-post/x-post.tsx
+++ b/components/tool-ui/x-post/x-post.tsx
@@ -9,15 +9,10 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./_adapter";
-import {
-  ActionButtons,
-  normalizeActionsConfig,
-  type ActionsProp,
-  formatRelativeTime,
-  formatCount,
-  getDomain,
-} from "../shared";
+} from "./_adapter";import { ActionButtons } from "../shared/action-buttons";
+import { normalizeActionsConfig, type ActionsProp } from "../shared/actions-config";
+import { formatCount, formatRelativeTime, getDomain } from "../shared/utils";
+
 import { resolveSafeNavigationHref } from "../shared/media";
 import type { XPostData, XPostMedia, XPostLinkPreview } from "./schema";
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -51,13 +51,8 @@ const eslintConfig = defineConfig([
     },
   },
   {
-    files: [
-      "components/tool-ui/data-table/**/*.{ts,tsx}",
-      "components/tool-ui/message-draft/**/*.{ts,tsx}",
-      "components/tool-ui/option-list/**/*.{ts,tsx}",
-      "components/tool-ui/plan/**/*.{ts,tsx}",
-      "components/tool-ui/progress-tracker/**/*.{ts,tsx}",
-    ],
+    files: ["components/tool-ui/**/*.ts", "components/tool-ui/**/*.tsx"],
+    ignores: ["components/tool-ui/shared/**/*.ts", "components/tool-ui/shared/**/*.tsx"],
     rules: {
       "no-restricted-imports": [
         "error",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "registry:build": "tsx scripts/build-tool-ui-registry.ts",
     "registry:check": "pnpm registry:build && git diff --exit-code -- public/r",
     "lint": "eslint .",
-    "lint:ci": "eslint components/tool-ui/data-table components/tool-ui/message-draft components/tool-ui/option-list components/tool-ui/plan components/tool-ui/progress-tracker components/tool-ui/weather-widget/effects/glass-panel-svg.tsx lib/registry/tool-ui-registry.ts lib/tests/registry lib/tests/tool-ui lib/tests/setup scripts/build-tool-ui-registry.ts eslint.config.ts vitest.config.ts",
+    "lint:ci": "eslint components/tool-ui lib/registry/tool-ui-registry.ts lib/tests/registry lib/tests/tool-ui lib/tests/setup scripts/build-tool-ui-registry.ts eslint.config.ts vitest.config.ts",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- migrate all remaining `components/tool-ui/**` imports from the `../shared` barrel to direct shared module imports
- expand the no-barrel lint guard from the 5 pilot components to all tool-ui components
- update `lint:ci` to lint the full `components/tool-ui` tree so the guard is enforced in CI
- fix two pre-existing lint failures in `weather-widget/effects/canvas-resolver.ts` (unused imports)

## Result
- `../shared` barrel imports in tool-ui components: **0**
- tool-ui components still using barrel imports: **0 / 25**

## Validation
- `pnpm lint:ci`
- `pnpm typecheck`
- `pnpm test`
- `pnpm registry:check`
