### PR TITLE
Promote Source and Install in component docs

### DIFF
--- a/app/docs/approval-card/content.mdx
+++ b/app/docs/approval-card/content.mdx
@@ -43,7 +43,19 @@ import { ApprovalCard } from "@/components/tool-ui/approval-card";
 
 > **Note:** Buttons use a responsive layout—they appear as compact pills at wider widths and stack full-width on narrow containers.
 
-## Features
+## Source and Install
+
+Source code: [components/tool-ui/approval-card](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/approval-card)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/approval-card.json
+```
+
+This command installs `components/tool-ui/approval-card`, `components/tool-ui/shared` into your project.
+
+## Key Features
 
 <FeatureGrid>
   <Feature icon="ShieldCheck" title="Human-in-the-loop">
@@ -130,16 +142,6 @@ Use `variant="destructive"` for dangerous or irreversible actions. This changes 
     ```
   </Tab>
 </Tabs>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/approval-card.json
-```
-
-This command installs `components/tool-ui/approval-card`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/audio/content.mdx
+++ b/app/docs/audio/content.mdx
@@ -42,6 +42,18 @@ import { Audio } from "@/components/tool-ui/audio";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/audio](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/audio)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/audio.json
+```
+
+This command installs `components/tool-ui/audio`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -58,16 +70,6 @@ import { Audio } from "@/components/tool-ui/audio";
     Display artist, album, or source information with optional link
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/audio.json
-```
-
-This command installs `components/tool-ui/audio`, `components/tool-ui/shared` into your project.
 
 ## Props
 

--- a/app/docs/chart/content.mdx
+++ b/app/docs/chart/content.mdx
@@ -8,6 +8,18 @@ import { DocsHeader } from "../_components/docs-header";
 
 <ChartPresetExample preset="revenue" />
 
+## Source and Install
+
+Source code: [components/tool-ui/chart](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/chart)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/chart.json
+```
+
+This command installs `components/tool-ui/chart`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -38,16 +50,6 @@ Switch to line charts for time-series or continuous data.
 Charts work with just `data`, `xKey`, and `series`. Title, description, legend, and grid are optional.
 
 <ChartPresetExample preset="minimal" />
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/chart.json
-```
-
-This command installs `components/tool-ui/chart`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/citation/content.mdx
+++ b/app/docs/citation/content.mdx
@@ -42,6 +42,18 @@ import { Citation } from "@/components/tool-ui/citation";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/citation](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/citation)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/citation.json
+```
+
+This command installs `components/tool-ui/citation`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -58,16 +70,6 @@ import { Citation } from "@/components/tool-ui/citation";
     Full keyboard navigation for stacked variant popover
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/citation.json
-```
-
-This command installs `components/tool-ui/citation`, `components/tool-ui/shared` into your project.
 
 ## Props
 

--- a/app/docs/code-block/content.mdx
+++ b/app/docs/code-block/content.mdx
@@ -8,6 +8,18 @@ import { DocsHeader } from "../_components/docs-header";
 
 <CodeBlockPresetExample preset="typescript" />
 
+## Source and Install
+
+Source code: [components/tool-ui/code-block](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/code-block)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/code-block.json
+```
+
+This command installs `components/tool-ui/code-block`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -24,16 +36,6 @@ import { DocsHeader } from "../_components/docs-header";
     Show filename and language badge for context
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/code-block.json
-```
-
-This command installs `components/tool-ui/code-block`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/data-table/content.mdx
+++ b/app/docs/data-table/content.mdx
@@ -161,6 +161,18 @@ import {
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/data-table](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/data-table)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/data-table.json
+```
+
+This command installs `components/tool-ui/data-table`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -189,16 +201,6 @@ Use explicit components when you want to force a layout:
 ```tsx
 import { DataTable } from "@/components/tool-ui/data-table";
 ```
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/data-table.json
-```
-
-This command installs `components/tool-ui/data-table`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/image-gallery/content.mdx
+++ b/app/docs/image-gallery/content.mdx
@@ -90,6 +90,18 @@ import { ImageGallery } from "@/components/tool-ui/image-gallery";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/image-gallery](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/image-gallery)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/image-gallery.json
+```
+
+This command installs `components/tool-ui/image-gallery`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -106,16 +118,6 @@ import { ImageGallery } from "@/components/tool-ui/image-gallery";
     Cap visible images with a "+N more" overlay
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/image-gallery.json
-```
-
-This command installs `components/tool-ui/image-gallery`, `components/tool-ui/shared` into your project.
 
 ## Props
 

--- a/app/docs/image/content.mdx
+++ b/app/docs/image/content.mdx
@@ -44,6 +44,18 @@ import { Image } from "@/components/tool-ui/image";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/image](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/image)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/image.json
+```
+
+This command installs `components/tool-ui/image`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -57,16 +69,6 @@ import { Image } from "@/components/tool-ui/image";
     Support for 1:1, 4:3, 16:9, 9:16, or auto
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/image.json
-```
-
-This command installs `components/tool-ui/image`, `components/tool-ui/shared` into your project.
 
 ## Props
 

--- a/app/docs/instagram-post/content.mdx
+++ b/app/docs/instagram-post/content.mdx
@@ -67,6 +67,18 @@ import { InstagramPost } from "@/components/tool-ui/instagram-post";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/instagram-post](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/instagram-post)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/instagram-post.json
+```
+
+This command installs `components/tool-ui/instagram-post`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -83,16 +95,6 @@ import { InstagramPost } from "@/components/tool-ui/instagram-post";
     Supports verified author badges and creator context
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/instagram-post.json
-```
-
-This command installs `components/tool-ui/instagram-post`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/item-carousel/content.mdx
+++ b/app/docs/item-carousel/content.mdx
@@ -8,6 +8,18 @@ import { DocsHeader } from "../_components/docs-header";
 
 <ItemCarouselPresetExample preset="recommendations" />
 
+## Source and Install
+
+Source code: [components/tool-ui/item-carousel](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/item-carousel)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/item-carousel.json
+```
+
+This command installs `components/tool-ui/item-carousel`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -44,16 +56,6 @@ How the Item Carousel handles common interaction patterns:
 **Click delegation:** Cards can be interactive (`onItemClick`) while containing action buttons. Click handlers check if the event originated from a button and delegate appropriately, preventing double-firing.
 
 **Touch optimization:** Cards use `touch-manipulation` to eliminate the 300ms tap delay on iOS. Navigation buttons appear only on hover/focus (desktop) and use backdrop blur for visual polish.
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/item-carousel.json
-```
-
-This command installs `components/tool-ui/item-carousel`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/link-preview/content.mdx
+++ b/app/docs/link-preview/content.mdx
@@ -42,6 +42,18 @@ import { LinkPreview } from "@/components/tool-ui/link-preview";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/link-preview](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/link-preview)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/link-preview.json
+```
+
+This command installs `components/tool-ui/link-preview`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -58,16 +70,6 @@ import { LinkPreview } from "@/components/tool-ui/link-preview";
     Add custom action buttons below the preview card
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/link-preview.json
-```
-
-This command installs `components/tool-ui/link-preview`, `components/tool-ui/shared` into your project.
 
 ## Props
 

--- a/app/docs/linkedin-post/content.mdx
+++ b/app/docs/linkedin-post/content.mdx
@@ -51,6 +51,18 @@ import { LinkedInPost } from "@/components/tool-ui/linkedin-post";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/linkedin-post](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/linkedin-post)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/linkedin-post.json
+```
+
+This command installs `components/tool-ui/linkedin-post`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -67,16 +79,6 @@ import { LinkedInPost } from "@/components/tool-ui/linkedin-post";
     Supports rich previews with title, image, and domain metadata
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/linkedin-post.json
-```
-
-This command installs `components/tool-ui/linkedin-post`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/message-draft/content.mdx
+++ b/app/docs/message-draft/content.mdx
@@ -52,6 +52,18 @@ onCancel={() => console.log("Cancelled")}
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/message-draft](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/message-draft)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/message-draft.json
+```
+
+This command installs `components/tool-ui/message-draft`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -188,16 +200,6 @@ When `outcome` is set, the component renders a compact receipt showing the resul
     </div>
   </Tab>
 </Tabs>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/message-draft.json
-```
-
-This command installs `components/tool-ui/message-draft`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/option-list/content.mdx
+++ b/app/docs/option-list/content.mdx
@@ -8,6 +8,18 @@ import { DocsHeader } from "../_components/docs-header";
 
 <OptionListPresetExample preset="max-selections" />
 
+## Source and Install
+
+Source code: [components/tool-ui/option-list](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/option-list)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/option-list.json
+```
+
+This command installs `components/tool-ui/option-list`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -36,16 +48,6 @@ The receipt state:
 - Shows only the confirmed option(s) with a checkmark
 - Hides unselected options and response actions
 - Is read-only (no interaction)
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/option-list.json
-```
-
-This command installs `components/tool-ui/option-list`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/order-summary/content.mdx
+++ b/app/docs/order-summary/content.mdx
@@ -82,6 +82,18 @@ import { OrderSummary } from "@/components/tool-ui/order-summary";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/order-summary](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/order-summary)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/order-summary.json
+```
+
+This command installs `components/tool-ui/order-summary`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -201,16 +213,6 @@ Use the `discount` and `discountLabel` fields in pricing to show promotional sav
     ```
   </Tab>
 </Tabs>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/order-summary.json
-```
-
-This command installs `components/tool-ui/order-summary`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/parameter-slider/content.mdx
+++ b/app/docs/parameter-slider/content.mdx
@@ -44,6 +44,18 @@ import { ParameterSlider } from "@/components/tool-ui/parameter-slider";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/parameter-slider](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/parameter-slider)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/parameter-slider.json
+```
+
+This command installs `components/tool-ui/parameter-slider`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -60,16 +72,6 @@ import { ParameterSlider } from "@/components/tool-ui/parameter-slider";
     Keyboard navigation and screen reader support
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/parameter-slider.json
-```
-
-This command installs `components/tool-ui/parameter-slider`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/plan/content.mdx
+++ b/app/docs/plan/content.mdx
@@ -8,6 +8,18 @@ import { DocsHeader } from "../_components/docs-header";
 
 <PlanPresetExample preset="comprehensive" />
 
+## Source and Install
+
+Source code: [components/tool-ui/plan](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/plan)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/plan.json
+```
+
+This command installs `components/tool-ui/plan`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -24,16 +36,6 @@ import { DocsHeader } from "../_components/docs-header";
     Visual feedback when all tasks complete
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/plan.json
-```
-
-This command installs `components/tool-ui/plan`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/preferences-panel/content.mdx
+++ b/app/docs/preferences-panel/content.mdx
@@ -95,6 +95,18 @@ import { PreferencesPanel } from "@/components/tool-ui/preferences-panel";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/preferences-panel](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/preferences-panel)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/preferences-panel.json
+```
+
+This command installs `components/tool-ui/preferences-panel`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -112,16 +124,6 @@ import { PreferencesPanel } from "@/components/tool-ui/preferences-panel";
     Group related settings with optional section headings
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/preferences-panel.json
-```
-
-This command installs `components/tool-ui/preferences-panel`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/progress-tracker/content.mdx
+++ b/app/docs/progress-tracker/content.mdx
@@ -76,6 +76,18 @@ import { ProgressTracker } from "@/components/tool-ui/progress-tracker";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/progress-tracker](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/progress-tracker)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/progress-tracker.json
+```
+
+This command installs `components/tool-ui/progress-tracker`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -214,16 +226,6 @@ Pass `elapsedTime` in milliseconds to display a timer badge. Automatically forma
     ```
   </Tab>
 </Tabs>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/progress-tracker.json
-```
-
-This command installs `components/tool-ui/progress-tracker`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/question-flow/content.mdx
+++ b/app/docs/question-flow/content.mdx
@@ -8,6 +8,18 @@ import { DocsHeader } from "../_components/docs-header";
 
 <QuestionFlowPresetExample preset="upfront" />
 
+## Source and Install
+
+Source code: [components/tool-ui/question-flow](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/question-flow)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/question-flow.json
+```
+
+This command installs `components/tool-ui/question-flow`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -56,16 +68,6 @@ The receipt state:
 - Shows a "Complete" badge with the configuration title
 - Displays a summary of all choices made during the flow
 - Is read-only (no interaction)
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/question-flow.json
-```
-
-This command installs `components/tool-ui/question-flow`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/stats-display/content.mdx
+++ b/app/docs/stats-display/content.mdx
@@ -103,7 +103,19 @@ import { StatsDisplay } from "@/components/tool-ui/stats-display";
   </Tab>
 </Tabs>
 
-## Features
+## Source and Install
+
+Source code: [components/tool-ui/stats-display](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/stats-display)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/stats-display.json
+```
+
+This command installs `components/tool-ui/stats-display`, `components/tool-ui/shared` into your project.
+
+## Key Features
 
 <FeatureGrid>
   <Feature icon="Grid2x2" title="Auto-responsive grid">
@@ -122,16 +134,6 @@ import { StatsDisplay } from "@/components/tool-ui/stats-display";
     Pass a single stat for a larger, centered presentation
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/stats-display.json
-```
-
-This command installs `components/tool-ui/stats-display`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/terminal/content.mdx
+++ b/app/docs/terminal/content.mdx
@@ -8,6 +8,18 @@ import { DocsHeader } from "../_components/docs-header";
 
 <TerminalPresetExample preset="success" />
 
+## Source and Install
+
+Source code: [components/tool-ui/terminal](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/terminal)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/terminal.json
+```
+
+This command installs `components/tool-ui/terminal`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -24,16 +36,6 @@ import { DocsHeader } from "../_components/docs-header";
     Errors are visually distinct from standard output
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/terminal.json
-```
-
-This command installs `components/tool-ui/terminal`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/video/content.mdx
+++ b/app/docs/video/content.mdx
@@ -44,6 +44,18 @@ import { Video } from "@/components/tool-ui/video";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/video](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/video)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/video.json
+```
+
+This command installs `components/tool-ui/video`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -60,16 +72,6 @@ import { Video } from "@/components/tool-ui/video";
     Support for auto, 1:1, 4:3, 16:9, and 9:16 formats
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/video.json
-```
-
-This command installs `components/tool-ui/video`, `components/tool-ui/shared` into your project.
 
 ## Props
 

--- a/app/docs/weather-widget/content.mdx
+++ b/app/docs/weather-widget/content.mdx
@@ -67,6 +67,18 @@ import { WeatherWidget } from "@/components/tool-ui/weather-widget/runtime";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/weather-widget](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/weather-widget)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/weather-widget.json
+```
+
+This command installs `components/tool-ui/weather-widget`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -83,16 +95,6 @@ import { WeatherWidget } from "@/components/tool-ui/weather-widget/runtime";
     Display 1-7 day forecasts with high/low temperatures
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/weather-widget.json
-```
-
-This command installs `components/tool-ui/weather-widget`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/app/docs/x-post/content.mdx
+++ b/app/docs/x-post/content.mdx
@@ -53,6 +53,18 @@ import { XPost } from "@/components/tool-ui/x-post";
   </Tab>
 </Tabs>
 
+## Source and Install
+
+Source code: [components/tool-ui/x-post](https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/x-post)
+
+Install this component directly from the Tool UI shadcn registry:
+
+```bash
+npx shadcn@latest add https://tool-ui.com/r/x-post.json
+```
+
+This command installs `components/tool-ui/x-post`, `components/tool-ui/shared` into your project.
+
 ## Key Features
 
 <FeatureGrid>
@@ -69,16 +81,6 @@ import { XPost } from "@/components/tool-ui/x-post";
     Built-in safe navigation helpers for external URLs
   </Feature>
 </FeatureGrid>
-
-## Source and Install
-
-Install this component directly from the Tool UI shadcn registry:
-
-```bash
-npx shadcn@latest add https://tool-ui.com/r/x-post.json
-```
-
-This command installs `components/tool-ui/x-post`, `components/tool-ui/shared` into your project.
 
 ## Usage
 

--- a/lib/tests/tool-ui/docs/registry-installation-contract.test.ts
+++ b/lib/tests/tool-ui/docs/registry-installation-contract.test.ts
@@ -6,6 +6,8 @@ const PROJECT_ROOT = process.cwd();
 const COMPONENTS_ROOT = path.join(PROJECT_ROOT, "components/tool-ui");
 const DOCS_ROOT = path.join(PROJECT_ROOT, "app/docs");
 const QUICK_START_DOC_PATH = path.join(DOCS_ROOT, "quick-start/content.mdx");
+const SOURCE_REPO_BASE_URL =
+  "https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui";
 
 function listDirectories(rootPath: string): string[] {
   return fs
@@ -32,11 +34,20 @@ describe("component docs registry installation contract", () => {
     for (const componentId of componentIds) {
       const docPath = path.join(DOCS_ROOT, componentId, "content.mdx");
       const content = fs.readFileSync(docPath, "utf8");
+      const sourceHeadingIndex = content.indexOf("## Source and Install");
+      const keyFeaturesHeadingIndex = content.indexOf("## Key Features");
 
       expect(content).toContain("## Source and Install");
+      expect(content).toContain("## Key Features");
       expect(content).toContain(
         `npx shadcn@latest add https://tool-ui.com/r/${componentId}.json`,
       );
+      expect(content).toContain(
+        `Source code: [components/tool-ui/${componentId}](${SOURCE_REPO_BASE_URL}/${componentId})`,
+      );
+      expect(sourceHeadingIndex).toBeGreaterThanOrEqual(0);
+      expect(keyFeaturesHeadingIndex).toBeGreaterThanOrEqual(0);
+      expect(sourceHeadingIndex).toBeLessThan(keyFeaturesHeadingIndex);
       expect(content).not.toContain("--cwd");
       expect(content).not.toContain("pnpm workspace");
       expect(content).not.toContain("### Download");


### PR DESCRIPTION
## Summary
- moved `## Source and Install` above `## Key Features` in all Tool UI component docs for better visibility
- normalized docs sections to use `## Key Features` where pages previously used `## Features`
- added a GitHub source link in each component's `Source and Install` section:
  - `https://github.com/assistant-ui/tool-ui/tree/main/components/tool-ui/<component-id>`
- updated docs contract tests to enforce:
  - `Source and Install` exists
  - `Key Features` exists
  - `Source and Install` appears before `Key Features`
  - each component doc includes both the GitHub source link and registry install command

## Validation
- `pnpm test -- lib/tests/tool-ui/docs/registry-installation-contract.test.ts`
- `pnpm lint:ci`
