### PR TITLE
Backfill PostHog instrumentation for docs refactor flows

### DIFF
--- a/app/docs/_components/component-docs-tabs.tsx
+++ b/app/docs/_components/component-docs-tabs.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { memo, useCallback, useRef, type ReactNode } from "react";
+import { memo, useCallback, useMemo, useRef, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import { cn } from "@/lib/ui/cn";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DocsBorderedShell } from "./docs-bordered-shell";
 import { DocsContent } from "./docs-content";
 import { useTabSearchParam } from "@/hooks/use-tab-search-param";
+import { analytics } from "@/lib/analytics";
+import { componentsRegistry } from "@/lib/docs/component-registry";
 
 type DocsTab = "docs" | "examples";
 
@@ -21,6 +24,11 @@ export const ComponentDocsTabs = memo(function ComponentDocsTabs({
   examples,
 }: ComponentDocsTabsProps) {
   const contentRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+  const componentMeta = useMemo(
+    () => componentsRegistry.find((component) => component.path === pathname),
+    [pathname],
+  );
 
   const { activeTab, setActiveTab } = useTabSearchParam<DocsTab>({
     defaultTab: "docs",
@@ -32,10 +40,13 @@ export const ComponentDocsTabs = memo(function ComponentDocsTabs({
   const handleTabChange = useCallback(
     (value: string) => {
       if (value === "docs" || value === "examples") {
+        if (componentMeta && value !== activeTab) {
+          analytics.component.tabSwitched(componentMeta.id, value);
+        }
         setActiveTab(value);
       }
     },
-    [setActiveTab],
+    [activeTab, componentMeta, setActiveTab],
   );
 
   return (

--- a/app/docs/_components/component-preview-shell.tsx
+++ b/app/docs/_components/component-preview-shell.tsx
@@ -142,6 +142,20 @@ export function ComponentPreviewShell({
     copy(code, COPY_ID);
   }, [componentId, code, copy]);
 
+  const handleViewModeChange = useCallback(
+    (nextViewMode: ViewMode) => {
+      if (nextViewMode === viewMode) return;
+
+      analytics.component.tabSwitched(componentId, nextViewMode);
+      analytics.component.previewInteracted(
+        componentId,
+        `view_mode_${nextViewMode}`,
+      );
+      setViewMode(nextViewMode);
+    },
+    [componentId, setViewMode, viewMode],
+  );
+
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-clip lg:flex-row">
       {/* Desktop sidebar */}
@@ -164,7 +178,10 @@ export function ComponentPreviewShell({
         <div className="flex flex-col gap-3 border-b px-4 pt-3 pb-3 lg:hidden">
           <div className="scrollbar-subtle overflow-x-auto">{sidebar}</div>
           <div className="flex items-center justify-end">
-            <ViewModeToggle value={viewMode} onValueChange={setViewMode} />
+            <ViewModeToggle
+              value={viewMode}
+              onValueChange={handleViewModeChange}
+            />
           </div>
         </div>
 
@@ -195,7 +212,10 @@ export function ComponentPreviewShell({
 
           {/* View mode toggle - top left corner */}
           <div className="absolute top-3 left-3 z-30 hidden lg:block">
-            <ViewModeToggle value={viewMode} onValueChange={setViewMode} />
+            <ViewModeToggle
+              value={viewMode}
+              onValueChange={handleViewModeChange}
+            />
           </div>
 
           {/* Copy button - top right corner (code view only) */}

--- a/app/docs/_components/copy-markdown-button.tsx
+++ b/app/docs/_components/copy-markdown-button.tsx
@@ -1,17 +1,24 @@
 "use client";
 
+import type { MouseEventHandler } from "react";
 import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
 import { Button } from "@/components/ui/button";
 import { Check, Copy as CopyIcon } from "lucide-react";
+import { analytics } from "@/lib/analytics";
 
 type CopyMarkdownButtonProps = {
   markdown: string;
 };
 
 export function CopyMarkdownButton({ markdown }: CopyMarkdownButtonProps) {
-  const [checked, onClick] = useCopyButton(async () => {
+  const [checked, copyMarkdown] = useCopyButton(async () => {
     await navigator.clipboard.writeText(markdown);
   });
+
+  const onClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    analytics.code.blockCopied("markdown", "docs_header");
+    copyMarkdown(event);
+  };
 
   return (
     <Button type="button" variant="outline" size="sm" onClick={onClick} aria-label="Copy page as Markdown" className="gap-2">
@@ -20,4 +27,3 @@ export function CopyMarkdownButton({ markdown }: CopyMarkdownButtonProps) {
     </Button>
   );
 }
-

--- a/app/docs/_components/docs-header.tsx
+++ b/app/docs/_components/docs-header.tsx
@@ -3,7 +3,6 @@ import { HeaderPreviewTabs } from "./header-preview-tabs";
 import { getMdxAsMarkdown } from "./mdx-to-markdown";
 import {
   isComponentId,
-  type ComponentId,
 } from "@/lib/docs/component-ids";
 
 type DocsHeaderProps = {

--- a/app/docs/_components/docs-nav.tsx
+++ b/app/docs/_components/docs-nav.tsx
@@ -5,7 +5,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { LayoutDashboardIcon } from "lucide-react";
+import { analytics } from "@/lib/analytics";
 import {
+  componentsRegistry,
   componentsByCategory,
   CATEGORY_META,
   type ComponentCategory,
@@ -21,6 +23,7 @@ export function DocsNav() {
   const [currentView] = useQueryState("view");
   const [collapsed, setCollapsed] = useState(false);
   const [isPressing, setIsPressing] = useState(false);
+  const previousPathRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     try {
@@ -46,6 +49,16 @@ export function DocsNav() {
     document.addEventListener("mouseup", handleMouseUp);
     return () => document.removeEventListener("mouseup", handleMouseUp);
   }, []);
+
+  React.useEffect(() => {
+    const component = componentsRegistry.find((entry) => entry.path === pathname);
+    if (component) {
+      const source = previousPathRef.current === "/docs/gallery" ? "gallery" : "direct";
+      analytics.component.viewed(component.id, source);
+    }
+
+    previousPathRef.current = pathname;
+  }, [pathname]);
 
   const buildLinkClasses = (isActive: boolean) =>
     cn(
@@ -91,6 +104,7 @@ export function DocsNav() {
             className={buildLinkClasses(isGalleryActive)}
             title={collapsed ? "Gallery" : undefined}
             onMouseDown={handleLinkMouseDown}
+            onClick={() => analytics.docs.navigationClicked("Gallery", galleryPath)}
           >
             {!collapsed && (
               <div className="flex flex-col overflow-hidden">
@@ -120,6 +134,7 @@ export function DocsNav() {
                 className={buildLinkClasses(isActive)}
                 title={collapsed ? page.label : undefined}
                 onMouseDown={handleLinkMouseDown}
+                onClick={() => analytics.docs.navigationClicked(page.label, page.path)}
               >
                 {!collapsed && (
                   <div className="overflow-hidden">
@@ -160,6 +175,9 @@ export function DocsNav() {
                   className={buildLinkClasses(isActive)}
                   title={collapsed ? component.label : undefined}
                   onMouseDown={handleLinkMouseDown}
+                  onClick={() =>
+                    analytics.docs.navigationClicked(component.label, href)
+                  }
                 >
                   {!collapsed && (
                     <div className="overflow-hidden">

--- a/app/docs/_components/docs-pager.tsx
+++ b/app/docs/_components/docs-pager.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 import { getAllDocsPageLinks } from "./docs-pages";
 import { cn } from "@/lib/ui/cn";
 import { Button } from "@/components/ui/button";
+import { analytics } from "@/lib/analytics";
 
 function useDocsPagination() {
   const pathname = usePathname();
@@ -42,6 +43,7 @@ function PagerLink({ href, label, direction }: PagerLinkProps) {
     >
       <Link
         href={href}
+        onClick={() => analytics.docs.navigationClicked(label, href)}
         className={cn(
           "inline-flex items-center gap-3",
           isPrev ? "text-left" : "text-right",

--- a/app/docs/_components/docs-toc.tsx
+++ b/app/docs/_components/docs-toc.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/ui/cn";
 import { useDocsToc } from "./docs-toc-context";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { useTocKeyboardNav } from "@/hooks/use-toc-keyboard-nav";
+import { analytics } from "@/lib/analytics";
 
 export function DocsToc() {
   const { scrollContainer, headings, activeId } = useDocsToc();
@@ -40,8 +41,13 @@ export function DocsToc() {
     scrollToHeading,
   );
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+  const handleClick = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    id: string,
+    title: string,
+  ) => {
     e.preventDefault();
+    analytics.docs.tocLinkClicked(title, 2);
     scrollToHeading(id);
   };
 
@@ -123,7 +129,7 @@ export function DocsToc() {
             key={heading.id}
             ref={setLinkRef(index)}
             href={`#${heading.id}`}
-            onClick={(e) => handleClick(e, heading.id)}
+            onClick={(e) => handleClick(e, heading.id, heading.text)}
             className={cn(
               "relative block py-1 text-sm transition-colors",
               "hover:text-foreground focus-visible:outline-none focus-visible:text-foreground",

--- a/app/docs/_components/gallery-docs-link.tsx
+++ b/app/docs/_components/gallery-docs-link.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { analytics } from "@/lib/analytics";
+
+interface GalleryDocsLinkProps {
+  componentId: string;
+  componentName: string;
+  href: string;
+  className?: string;
+}
+
+export function GalleryDocsLink({
+  componentId,
+  componentName,
+  href,
+  className,
+}: GalleryDocsLinkProps) {
+  const handleClick = () => {
+    analytics.gallery.componentClicked(componentId);
+    analytics.docs.navigationClicked(componentName, href);
+  };
+
+  return (
+    <Link href={href} className={className} onClick={handleClick}>
+      <span>View Docs</span>
+      <ArrowRight className="size-3" aria-hidden="true" />
+    </Link>
+  );
+}

--- a/app/docs/_components/header-preview-tabs.tsx
+++ b/app/docs/_components/header-preview-tabs.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from "react";
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { analytics } from "@/lib/analytics";
 import {
   type ComponentId,
   getPreviewConfig,
@@ -17,14 +18,30 @@ const EMPTY_STATE: PreviewState = {};
 
 export function HeaderPreviewTabs({ componentId }: HeaderPreviewTabsProps) {
   const config = getPreviewConfig(componentId);
-  if (!config) {
-    return null;
-  }
   const [state, setState] = useState<PreviewState>(EMPTY_STATE);
 
   const handleSetState = useCallback((partialState: Partial<PreviewState>) => {
     setState((prev) => ({ ...prev, ...partialState }));
   }, []);
+
+  const handleTabClickCapture = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement;
+      const trigger = target.closest('[role="tab"]');
+      if (!trigger) return;
+      if (trigger.getAttribute("aria-selected") === "true") return;
+
+      const rawLabel = trigger.textContent?.trim().toLowerCase();
+      if (rawLabel === "preview" || rawLabel === "code") {
+        analytics.component.tabSwitched(componentId, `header_${rawLabel}`);
+      }
+    },
+    [componentId],
+  );
+
+  if (!config) {
+    return null;
+  }
 
   const preset = config.presets[config.defaultPreset];
   const preview = config.renderComponent({
@@ -41,7 +58,7 @@ export function HeaderPreviewTabs({ componentId }: HeaderPreviewTabsProps) {
   const code = preset.generateExampleCode(preset.data);
 
   return (
-    <div className="not-prose mt-6">
+    <div className="not-prose mt-6" onClickCapture={handleTabClickCapture}>
       <Tabs items={["Preview", "Code"]}>
         <Tab value="Preview">
           <div className="header-preview-center flex w-full justify-center">

--- a/app/docs/gallery/page.tsx
+++ b/app/docs/gallery/page.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
-import { ArrowRight } from "lucide-react";
-import Link from "next/link";
 import type { ReactNode } from "react";
 
 import { DocsBorderedShell } from "@/app/docs/_components/docs-bordered-shell";
+import { GalleryDocsLink } from "@/app/docs/_components/gallery-docs-link";
 import { DataTable } from "@/components/tool-ui/data-table";
 import { Image } from "@/components/tool-ui/image";
 import { ItemCarousel } from "@/components/tool-ui/item-carousel";
@@ -123,13 +122,12 @@ function GalleryPreviewCard({
       <div className="pointer-events-none absolute top-0 left-1/2 z-20 -translate-x-1/2 -translate-y-1 rounded-full border border-neutral-700/70 bg-neutral-900/90 px-3 py-1 text-[11px] font-medium tracking-wide text-neutral-100 opacity-0 shadow-sm backdrop-blur-sm transition-all duration-200 group-focus-within/gallery-card:translate-y-0 group-focus-within/gallery-card:opacity-100 group-hover/gallery-card:translate-y-0 group-hover/gallery-card:opacity-100 dark:border-neutral-300/80 dark:bg-neutral-100/90 dark:text-neutral-900">
         <span className="text-sm font-semibold">{componentMeta.name}</span>
         <span className="mx-1 text-neutral-400 dark:text-neutral-500">•</span>
-        <Link
+        <GalleryDocsLink
+          componentId={componentId}
+          componentName={componentMeta.name}
           href={componentMeta.docsHref}
           className="pointer-events-auto inline-flex items-center gap-1 text-xs text-neutral-200/90 underline-offset-2 hover:text-white hover:underline focus-visible:underline focus-visible:outline-none dark:text-neutral-700 dark:hover:text-neutral-950"
-        >
-          <span>View Docs</span>
-          <ArrowRight className="size-3" aria-hidden="true" />
-        </Link>
+        />
       </div>
       {children}
     </div>

--- a/lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
+++ b/lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const FILE_ASSERTIONS = [
+  {
+    file: "app/docs/_components/docs-nav.tsx",
+    needles: ["analytics.docs.navigationClicked(", "analytics.component.viewed("],
+  },
+  {
+    file: "app/docs/_components/docs-pager.tsx",
+    needles: ["analytics.docs.navigationClicked("],
+  },
+  {
+    file: "app/docs/_components/docs-toc.tsx",
+    needles: ["analytics.docs.tocLinkClicked("],
+  },
+  {
+    file: "app/docs/_components/copy-markdown-button.tsx",
+    needles: ["analytics.code.blockCopied("],
+  },
+  {
+    file: "app/docs/_components/component-docs-tabs.tsx",
+    needles: ["analytics.component.tabSwitched("],
+  },
+  {
+    file: "app/docs/_components/component-preview-shell.tsx",
+    needles: [
+      "analytics.component.tabSwitched(",
+      "analytics.component.previewInteracted(",
+    ],
+  },
+  {
+    file: "app/docs/_components/header-preview-tabs.tsx",
+    needles: ["analytics.component.tabSwitched("],
+  },
+  {
+    file: "app/docs/_components/gallery-docs-link.tsx",
+    needles: [
+      "analytics.gallery.componentClicked(",
+      "analytics.docs.navigationClicked(",
+    ],
+  },
+] as const;
+
+describe("docs analytics instrumentation contract", () => {
+  for (const { file, needles } of FILE_ASSERTIONS) {
+    test(`${file} includes analytics hooks`, () => {
+      const absolutePath = path.join(process.cwd(), file);
+      const content = fs.readFileSync(absolutePath, "utf8");
+
+      for (const needle of needles) {
+        expect(content).toContain(needle);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Backfill PostHog instrumentation across refactored docs interaction surfaces:
  - docs sidebar navigation
  - docs pager navigation
  - table of contents clicks
  - docs header "Copy as Markdown"
  - preview tabs/view mode switches
  - gallery "View Docs" clickthrough
- Add component-view tracking on docs route changes.
- Add regression coverage so analytics hooks stay wired through future refactors.

## Why
Recent docs/UI refactors changed primary interaction surfaces and left gaps in event coverage. This restores high-signal engagement/conversion tracking.

## Validation
- `pnpm typecheck`
- `pnpm test -- lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts lib/tests/tool-ui/docs/header-preview-tabs-runtime-contract.test.ts lib/tests/tool-ui/docs/docs-header-server-contract.test.ts`

## PostHog QA Assets
- Dashboard: https://us.posthog.com/project/294938/dashboard/1272838
- Insights:
  - https://us.posthog.com/project/294938/insights/zqlmUzuQ
  - https://us.posthog.com/project/294938/insights/mnk38yyT
  - https://us.posthog.com/project/294938/insights/rStWujvu