### PR TITLE
Track code_block_copied from component preview copy

### DIFF
--- a/app/docs/_components/component-preview-shell.tsx
+++ b/app/docs/_components/component-preview-shell.tsx
@@ -139,6 +139,7 @@ export function ComponentPreviewShell({
 
   const handleCopy = useCallback(() => {
     analytics.component.codeCopied(componentId, "full");
+    analytics.code.blockCopied("tsx", "component_preview");
     copy(code, COPY_ID);
   }, [componentId, code, copy]);
 

--- a/lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
+++ b/lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
@@ -28,6 +28,7 @@ const FILE_ASSERTIONS = [
     needles: [
       "analytics.component.tabSwitched(",
       "analytics.component.previewInteracted(",
+      "analytics.code.blockCopied(",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- also emit `code_block_copied` when users click the component preview "Copy code" action
- keep existing `component_code_copied` event intact
- extend docs analytics instrumentation contract test to cover this hook

## Validation
- pnpm test -- lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
- pnpm typecheck