### PR TITLE
Track docs installation snippet copy events

### DIFF
--- a/app/docs/_components/tracked-dynamic-codeblock.tsx
+++ b/app/docs/_components/tracked-dynamic-codeblock.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback } from "react";
+import {
+  DynamicCodeBlock,
+  type DynamicCodeblockProps,
+} from "fumadocs-ui/components/dynamic-codeblock";
+import { analytics } from "@/lib/analytics";
+import {
+  detectInstallSnippetType,
+  getDocsCodeCopySource,
+} from "@/lib/docs/install-snippet-analytics";
+
+export function TrackedDynamicCodeBlock({
+  lang,
+  code,
+  codeblock,
+  ...props
+}: DynamicCodeblockProps) {
+  const installSnippetType = detectInstallSnippetType(code);
+  const source = getDocsCodeCopySource(installSnippetType);
+
+  const Actions = useCallback(
+    ({ className, children }: { className?: string; children?: ReactNode }) => (
+      <div
+        className={className}
+        onClick={(event) => {
+          const target = event.target as HTMLElement | null;
+          const clickedCopyButton = target?.closest("button");
+          if (!clickedCopyButton) return;
+
+          analytics.code.blockCopied(lang, source);
+          if (installSnippetType) {
+            analytics.docs.installSnippetCopied(
+              installSnippetType,
+              "docs_code_block",
+            );
+          }
+        }}
+      >
+        {children}
+      </div>
+    ),
+    [installSnippetType, lang, source],
+  );
+
+  return (
+    <DynamicCodeBlock
+      lang={lang}
+      code={code}
+      codeblock={{ ...codeblock, Actions }}
+      {...props}
+    />
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -105,6 +105,16 @@ export const analytics = {
         heading_title: headingTitle,
         heading_depth: headingDepth,
       }),
+
+    /** Installation command copy intent (high-conversion docs action) */
+    installSnippetCopied: (
+      snippetType: "skills" | "registry" | "package_manager",
+      location: "docs_code_block" | "docs_header",
+    ) =>
+      trackEvent("install_snippet_copied", {
+        snippet_type: snippetType,
+        location,
+      }),
   },
 
   code: {

--- a/lib/docs/install-snippet-analytics.ts
+++ b/lib/docs/install-snippet-analytics.ts
@@ -1,0 +1,27 @@
+export type InstallSnippetType = "skills" | "registry" | "package_manager";
+
+const SKILLS_INSTALL_PATTERN = /(?:^|\n)\s*npx\s+skills\s+add\b/i;
+const REGISTRY_INSTALL_PATTERN = /(?:^|\n)\s*npx\s+shadcn@latest\s+add\b/i;
+const PACKAGE_INSTALL_PATTERN = /(?:^|\n)\s*(?:npm|pnpm|yarn|bun)\s+(?:install|add)\b/i;
+
+export function detectInstallSnippetType(code: string): InstallSnippetType | null {
+  if (SKILLS_INSTALL_PATTERN.test(code)) {
+    return "skills";
+  }
+
+  if (REGISTRY_INSTALL_PATTERN.test(code)) {
+    return "registry";
+  }
+
+  if (PACKAGE_INSTALL_PATTERN.test(code)) {
+    return "package_manager";
+  }
+
+  return null;
+}
+
+export function getDocsCodeCopySource(
+  installSnippetType: InstallSnippetType | null,
+): "docs_installation" | "docs_code_block" {
+  return installSnippetType ? "docs_installation" : "docs_code_block";
+}

--- a/lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
+++ b/lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
@@ -20,6 +20,17 @@ const FILE_ASSERTIONS = [
     needles: ["analytics.code.blockCopied("],
   },
   {
+    file: "app/docs/_components/tracked-dynamic-codeblock.tsx",
+    needles: [
+      "analytics.code.blockCopied(",
+      "analytics.docs.installSnippetCopied(",
+    ],
+  },
+  {
+    file: "mdx-components.tsx",
+    needles: ["TrackedDynamicCodeBlock"],
+  },
+  {
     file: "app/docs/_components/component-docs-tabs.tsx",
     needles: ["analytics.component.tabSwitched("],
   },

--- a/lib/tests/tool-ui/docs/install-snippet-analytics.test.ts
+++ b/lib/tests/tool-ui/docs/install-snippet-analytics.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import {
+  detectInstallSnippetType,
+  getDocsCodeCopySource,
+} from "@/lib/docs/install-snippet-analytics";
+
+describe("install snippet analytics helpers", () => {
+  test("detects skills install commands", () => {
+    const snippet =
+      "npx skills add https://github.com/assistant-ui/tool-ui --skill tool-ui";
+    expect(detectInstallSnippetType(snippet)).toBe("skills");
+  });
+
+  test("detects shadcn registry install commands", () => {
+    const snippet = "npx shadcn@latest add https://tool-ui.com/r/plan.json";
+    expect(detectInstallSnippetType(snippet)).toBe("registry");
+  });
+
+  test("detects package-manager install commands", () => {
+    const snippet = "pnpm add @assistant-ui/react";
+    expect(detectInstallSnippetType(snippet)).toBe("package_manager");
+  });
+
+  test("returns null for non-install snippets", () => {
+    const snippet = "const x = 1;";
+    expect(detectInstallSnippetType(snippet)).toBeNull();
+  });
+
+  test("maps install snippets to install copy source", () => {
+    expect(getDocsCodeCopySource("skills")).toBe("docs_installation");
+    expect(getDocsCodeCopySource(null)).toBe("docs_code_block");
+  });
+});

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -9,11 +9,11 @@ import {
   Tab,
 } from "fumadocs-ui/components/tabs";
 import { TypeTable } from "fumadocs-ui/components/type-table";
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { Files, File, Folder } from "fumadocs-ui/components/files";
 import * as React from "react";
 import dynamic from "next/dynamic";
 import { AutoLinkChildren, withAutoLink } from "@/lib/docs/auto-link";
+import { TrackedDynamicCodeBlock } from "@/app/docs/_components/tracked-dynamic-codeblock";
 
 const Mermaid = dynamic(() =>
   import("@/app/components/mdx/mermaid").then((m) => m.Mermaid)
@@ -110,7 +110,9 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
           "data-line-numbers-start": 1,
         };
 
-        return <DynamicCodeBlock lang={lang} code={code} codeblock={attrs} />;
+        return (
+          <TrackedDynamicCodeBlock lang={lang} code={code} codeblock={attrs} />
+        );
       }
 
       return React.createElement("pre", props);


### PR DESCRIPTION
## Summary
- instrument docs MDX code-block copy actions through a shared tracked wrapper
- emit `code_block_copied` for all docs snippet copies with source classification
- emit new `install_snippet_copied` event for install commands (`npx skills add`, `npx shadcn@latest add`, package-manager install/add)
- wire the MDX `pre` renderer to the tracked code-block component, so Agent Skills install snippets are covered automatically

## Validation
- pnpm test -- lib/tests/tool-ui/docs/install-snippet-analytics.test.ts lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
- pnpm typecheck
- pnpm exec eslint app/docs/_components/tracked-dynamic-codeblock.tsx mdx-components.tsx lib/analytics.ts lib/docs/install-snippet-analytics.ts lib/tests/tool-ui/docs/install-snippet-analytics.test.ts lib/tests/tool-ui/docs/analytics-instrumentation-contract.test.ts
