### PR TITLE
docs(contributing): clarify schema boundary entrypoints

### DIFF
--- a/app/docs/contributing/content.mdx
+++ b/app/docs/contributing/content.mdx
@@ -17,7 +17,8 @@ Each component lives in [`components/tool-ui/`](https://github.com/assistant-ui/
 - `schema.ts`: Serializable schema + strict/safe parsers (`SerializableXSchema`, `parseSerializableX`, `safeParseSerializableX`)
 - `types.ts` (optional): TypeScript type definitions when component complexity justifies a dedicated file
 - `component-name.tsx`: Main component implementation
-- `index.ts` or `index.tsx`: Public exports (component, types, parser)
+- `index.ts` or `index.tsx`: Public UI exports only (component + UI-facing types)
+- `<component>/schema` entrypoint: import schema values and parse helpers from this path (not from the main index)
 
 ### Sub-Components (as needed)
 
@@ -73,7 +74,7 @@ Implementation pattern:
    - Minimal but clear chrome
 5. Sub-components: Extract header/body/footer/actions when the component grows
 6. `context.tsx`: Use React context only when sub-components genuinely need shared state
-7. `index.tsx`: Export the public API (component, types, strict/safe parsers)
+7. `index.tsx`: Export only the UI surface (component + UI-facing types); export strict/safe parsers from `.../schema`
 
 </Step>
 


### PR DESCRIPTION
## Summary
- clarify that component main entrypoints are UI-only
- document that schema values and parser helpers must be imported from `.../schema` (for example `@/components/tool-ui/plan/schema`)
- remove outdated maintainer-guide wording that implied parser exports from main index

## Validation
- docs-only change