### PR TITLE
Fix landing nav intro flash before entrance animation

### DIFF
--- a/app/components/layout/app-shell.tsx
+++ b/app/components/layout/app-shell.tsx
@@ -48,15 +48,13 @@ export function HeaderFrame(props: HeaderFrameProps) {
 }
 
 export function AnimatedHeaderFrame(props: HeaderFrameProps) {
-  // Start with false to match server render, then update after hydration
-  const [shouldAnimate, setShouldAnimate] = useState(false);
+  const [shouldAnimate] = useState(() => !hasPlayedIntroAnimation);
 
   useEffect(() => {
-    if (!hasPlayedIntroAnimation) {
+    if (shouldAnimate) {
       hasPlayedIntroAnimation = true;
-      setShouldAnimate(true);
     }
-  }, []);
+  }, [shouldAnimate]);
 
   return <HeaderFrameBase {...props} shouldAnimate={shouldAnimate} />;
 }

--- a/lib/tests/layout/app-shell-header-animation-contract.test.ts
+++ b/lib/tests/layout/app-shell-header-animation-contract.test.ts
@@ -1,0 +1,21 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/components/layout/app-header.server", () => ({
+  ResponsiveHeader: () => createElement("header", { "data-slot": "responsive-header" }),
+}));
+
+describe("app shell header animation contract", () => {
+  it("includes the navbar entrance class on first render of AnimatedHeaderFrame", async () => {
+    vi.resetModules();
+
+    const { AnimatedHeaderFrame } = await import("@/app/components/layout/app-shell");
+
+    const html = renderToStaticMarkup(
+      createElement(AnimatedHeaderFrame, null, createElement("main", null, "content")),
+    );
+
+    expect(html).toContain("animate-navbar-fade-in");
+  });
+});


### PR DESCRIPTION
## Summary
- fix `AnimatedHeaderFrame` so first render can include the nav intro animation class
- preserve one-time intro behavior across client navigations
- add regression contract test for first render class presence

## Testing
- pnpm vitest run lib/tests/layout/app-shell-header-animation-contract.test.ts