### PR TITLE
docs(actions): clarify action model and action-centric exceptions

### DIFF
--- a/app/docs/actions/actions-examples.tsx
+++ b/app/docs/actions/actions-examples.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/tool-ui/preferences-panel";
 import { ToolUI, createDecisionResult } from "@/components/tool-ui/shared";
 import { Button } from "@/components/ui/button";
+import { MockMessage, MockThread } from "../_components/mock-thread";
 
 function formatSelection(value: OptionListSelection): string {
   if (value === null) return "No selection";
@@ -19,6 +20,24 @@ function formatSelection(value: OptionListSelection): string {
   }
   return value;
 }
+
+const tableRows = [
+  { id: "1", merchant: "Delta Airlines", amount: 847 },
+  { id: "2", merchant: "Acme Hotel", amount: 312 },
+];
+
+const orderItems = [
+  { id: "sku-1", name: "Wireless Keyboard", unitPrice: 89, quantity: 1 },
+  { id: "sku-2", name: "Mouse", unitPrice: 49, quantity: 1 },
+];
+
+const orderPricing = {
+  subtotal: 138,
+  shipping: 0,
+  tax: 12.42,
+  total: 150.42,
+  currency: "USD",
+};
 
 const initialSliderValues: SliderValue[] = [
   { id: "exposure", value: 0.2 },
@@ -51,16 +70,308 @@ const preferencesSections = [
   },
 ];
 
-export function ActionsExamples() {
-  const [localActionEvent, setLocalActionEvent] = useState(
-    "Try a local action below.",
+export function ActionFlowToolCallVisual() {
+  return (
+    <MockThread caption="Step 1: the model chooses a tool call.">
+      <MockMessage role="user">Show last month&apos;s travel expenses.</MockMessage>
+      <MockMessage role="assistant">
+        <div className="border-border bg-card rounded-xl border p-3 text-sm">
+          Calling <code>getExpenses</code> with args:
+          <pre className="bg-muted mt-2 overflow-x-auto rounded-md p-2 text-xs">
+{`{
+  "month": "2026-01",
+  "category": "travel"
+}`}
+          </pre>
+        </div>
+      </MockMessage>
+    </MockThread>
   );
+}
+
+export function ActionFlowRenderVisual() {
+  return (
+    <div className="not-prose max-w-2xl">
+      <DataTable
+        id="flow-render-surface"
+        rowIdKey="id"
+        columns={[
+          { key: "merchant", label: "Merchant" },
+          { key: "amount", label: "Amount", align: "right" },
+        ]}
+        data={tableRows}
+      />
+    </div>
+  );
+}
+
+export function ActionFlowUserActionVisual() {
+  const [event, setEvent] = useState("No action clicked yet.");
+
+  return (
+    <div className="not-prose flex max-w-2xl flex-col gap-3">
+      <ToolUI id="flow-local-action">
+        <ToolUI.Surface>
+          <DataTable
+            id="flow-local-action"
+            rowIdKey="id"
+            columns={[
+              { key: "merchant", label: "Merchant" },
+              { key: "amount", label: "Amount", align: "right" },
+            ]}
+            data={tableRows}
+          />
+        </ToolUI.Surface>
+        <ToolUI.Actions>
+          <ToolUI.LocalActions
+            actions={[
+              { id: "export-csv", label: "Export CSV", variant: "secondary" },
+              { id: "open-report", label: "Open Full Report", variant: "outline" },
+            ]}
+            onAction={(actionId) => {
+              setEvent(`Clicked: ${actionId}`);
+            }}
+          />
+        </ToolUI.Actions>
+      </ToolUI>
+      <p className="text-muted-foreground text-xs">{event}</p>
+    </div>
+  );
+}
+
+export function ActionFlowRuntimeHandleVisual() {
+  const [state, setState] = useState<"idle" | "handling" | "done">("idle");
+
+  return (
+    <div className="not-prose flex max-w-xl flex-col gap-3">
+      <div className="border-border bg-card rounded-xl border p-4">
+        <p className="text-sm font-medium">Runtime status</p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          {state === "idle" && "Waiting for a user action."}
+          {state === "handling" && "Handling action and running side effect..."}
+          {state === "done" && "Action handled successfully."}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            setState("handling");
+            setTimeout(() => setState("done"), 600);
+          }}
+        >
+          Simulate handler
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setState("idle")}>
+          Reset
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ActionFlowCommitVisual() {
   const [orderChoice, setOrderChoice] = useState<
     { action: "confirm"; orderId?: string; confirmedAt?: string } | undefined
   >();
-  const [decisionEvent, setDecisionEvent] = useState(
-    "No decision committed yet.",
+  const [event, setEvent] = useState("No decision committed yet.");
+
+  return (
+    <div className="not-prose flex max-w-md flex-col gap-3">
+      <ToolUI id="flow-decision">
+        <ToolUI.Surface>
+          <OrderSummary
+            id="flow-decision"
+            title="Order Summary"
+            items={orderItems}
+            pricing={orderPricing}
+            choice={orderChoice}
+          />
+        </ToolUI.Surface>
+        {!orderChoice && (
+          <ToolUI.Actions>
+            <ToolUI.DecisionActions
+              actions={[
+                { id: "cancel", label: "Cancel", variant: "outline" },
+                { id: "confirm", label: "Purchase", variant: "default" },
+              ]}
+              onAction={(action) =>
+                createDecisionResult({
+                  decisionId: "flow-order-decision",
+                  action,
+                  payload:
+                    action.id === "confirm"
+                      ? {
+                          orderId: `ORD-${Date.now()}`,
+                          confirmedAt: new Date().toISOString(),
+                        }
+                      : undefined,
+                })
+              }
+              onCommit={(result) => {
+                if (result.actionId !== "confirm") {
+                  setEvent("Decision cancelled.");
+                  return;
+                }
+
+                const orderId =
+                  typeof result.payload?.orderId === "string"
+                    ? result.payload.orderId
+                    : `ORD-${Date.now()}`;
+                const confirmedAt =
+                  typeof result.payload?.confirmedAt === "string"
+                    ? result.payload.confirmedAt
+                    : new Date().toISOString();
+
+                setOrderChoice({
+                  action: "confirm",
+                  orderId,
+                  confirmedAt,
+                });
+                setEvent(`Committed decision: ${orderId}`);
+              }}
+            />
+          </ToolUI.Actions>
+        )}
+      </ToolUI>
+      <div className="flex items-center gap-2">
+        <p className="text-muted-foreground text-xs">{event}</p>
+        {orderChoice && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setOrderChoice(undefined);
+              setEvent("Decision reset for demo.");
+            }}
+          >
+            Reset
+          </Button>
+        )}
+      </div>
+    </div>
   );
+}
+
+export function DisplaySurfaceLocalActionsExample() {
+  const [event, setEvent] = useState("Try a local action below.");
+
+  return (
+    <div className="not-prose flex max-w-2xl flex-col gap-3">
+      <ToolUI id="display-local-actions-table">
+        <ToolUI.Surface>
+          <DataTable
+            id="display-local-actions-table"
+            rowIdKey="id"
+            columns={[
+              { key: "merchant", label: "Merchant" },
+              { key: "amount", label: "Amount", align: "right" },
+            ]}
+            data={tableRows}
+          />
+        </ToolUI.Surface>
+        <ToolUI.Actions>
+          <ToolUI.LocalActions
+            actions={[
+              { id: "export-csv", label: "Export CSV", variant: "secondary" },
+              { id: "open-report", label: "Open Full Report", variant: "outline" },
+            ]}
+            onAction={(actionId) => {
+              setEvent(`Local action executed: ${actionId}`);
+            }}
+          />
+        </ToolUI.Actions>
+      </ToolUI>
+      <p className="text-muted-foreground text-xs">{event}</p>
+    </div>
+  );
+}
+
+export function DecisionSurfaceExample() {
+  const [orderChoice, setOrderChoice] = useState<
+    { action: "confirm"; orderId?: string; confirmedAt?: string } | undefined
+  >();
+  const [event, setEvent] = useState("No decision committed yet.");
+
+  return (
+    <div className="not-prose flex max-w-md flex-col gap-3">
+      <ToolUI id="decision-actions-order">
+        <ToolUI.Surface>
+          <OrderSummary
+            id="decision-actions-order"
+            title="Order Summary"
+            items={orderItems}
+            pricing={orderPricing}
+            choice={orderChoice}
+          />
+        </ToolUI.Surface>
+        {!orderChoice && (
+          <ToolUI.Actions>
+            <ToolUI.DecisionActions
+              actions={[
+                { id: "cancel", label: "Cancel", variant: "outline" },
+                { id: "confirm", label: "Purchase", variant: "default" },
+              ]}
+              onAction={(action) =>
+                createDecisionResult({
+                  decisionId: "decision-actions-order-decision",
+                  action,
+                  payload:
+                    action.id === "confirm"
+                      ? {
+                          orderId: `ORD-${Date.now()}`,
+                          confirmedAt: new Date().toISOString(),
+                        }
+                      : undefined,
+                })
+              }
+              onCommit={(result) => {
+                if (result.actionId !== "confirm") {
+                  setEvent("Decision cancelled.");
+                  return;
+                }
+
+                const orderId =
+                  typeof result.payload?.orderId === "string"
+                    ? result.payload.orderId
+                    : `ORD-${Date.now()}`;
+                const confirmedAt =
+                  typeof result.payload?.confirmedAt === "string"
+                    ? result.payload.confirmedAt
+                    : new Date().toISOString();
+
+                setOrderChoice({
+                  action: "confirm",
+                  orderId,
+                  confirmedAt,
+                });
+                setEvent(`Committed decision envelope: ${orderId}`);
+              }}
+            />
+          </ToolUI.Actions>
+        )}
+      </ToolUI>
+      <div className="flex items-center gap-2">
+        <p className="text-muted-foreground text-xs">{event}</p>
+        {orderChoice && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setOrderChoice(undefined);
+              setEvent("Decision reset for demo.");
+            }}
+          >
+            Reset
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ActionCentricExceptionsExample() {
   const [optionChoice, setOptionChoice] = useState<OptionListSelection>();
   const [optionEvent, setOptionEvent] = useState("No selection confirmed yet.");
   const [sliderValues, setSliderValues] = useState<SliderValue[]>(
@@ -76,284 +387,136 @@ export function ActionsExamples() {
   );
 
   return (
-    <div className="not-prose flex flex-col gap-10">
-      <section className="flex flex-col gap-3">
-        <h3 className="text-xl font-semibold tracking-tight">
-          Standard Surfaces: Display + Sibling Actions
-        </h3>
-        <p className="text-muted-foreground text-sm">
-          Most components follow this pattern. The display surface renders data.
-          Actions are composed as siblings with <code>ToolUI.Actions</code>.
-        </p>
-        <ToolUI id="local-actions-table">
-          <div className="flex max-w-2xl flex-col gap-3">
-            <ToolUI.Surface>
-              <DataTable
-                id="local-actions-table"
-                rowIdKey="id"
-                columns={[
-                  { key: "merchant", label: "Merchant" },
-                  { key: "amount", label: "Amount", align: "right" },
-                ]}
-                data={[
-                  { id: "1", merchant: "Delta Airlines", amount: 847 },
-                  { id: "2", merchant: "Acme Hotel", amount: 312 },
-                ]}
-              />
-            </ToolUI.Surface>
-            <ToolUI.Actions>
-              <ToolUI.LocalActions
-                actions={[
-                  { id: "export-csv", label: "Export CSV", variant: "secondary" },
-                  { id: "open-report", label: "Open Full Report", variant: "outline" },
-                ]}
-                onAction={(actionId) => {
-                  setLocalActionEvent(`Local action executed: ${actionId}`);
-                }}
-              />
-            </ToolUI.Actions>
-          </div>
-        </ToolUI>
-        <p className="text-muted-foreground text-xs">{localActionEvent}</p>
-      </section>
-
-      <section className="flex flex-col gap-3">
-        <h3 className="text-xl font-semibold tracking-tight">
-          Decision Surface: Envelope + Commit
-        </h3>
-        <p className="text-muted-foreground text-sm">
-          Use <code>ToolUI.DecisionActions</code> when the user choice should
-          commit a durable outcome.
-        </p>
-        <ToolUI id="decision-actions-order">
-          <div className="flex max-w-md flex-col gap-3">
-            <ToolUI.Surface>
-              <OrderSummary
-                id="decision-actions-order"
-                title="Order Summary"
-                items={[
-                  {
-                    id: "sku-1",
-                    name: "Wireless Keyboard",
-                    unitPrice: 89,
-                    quantity: 1,
-                  },
-                  { id: "sku-2", name: "Mouse", unitPrice: 49, quantity: 1 },
-                ]}
-                pricing={{
-                  subtotal: 138,
-                  shipping: 0,
-                  tax: 12.42,
-                  total: 150.42,
-                  currency: "USD",
-                }}
-                choice={orderChoice}
-              />
-            </ToolUI.Surface>
-            {!orderChoice && (
-              <ToolUI.Actions>
-                <ToolUI.DecisionActions
-                  actions={[
-                    { id: "cancel", label: "Cancel", variant: "outline" },
-                    { id: "confirm", label: "Purchase", variant: "default" },
-                  ]}
-                  onAction={(action) =>
-                    createDecisionResult({
-                      decisionId: "decision-actions-order-decision",
-                      action,
-                      payload:
-                        action.id === "confirm"
-                          ? {
-                              orderId: `ORD-${Date.now()}`,
-                              confirmedAt: new Date().toISOString(),
-                            }
-                          : undefined,
-                    })
-                  }
-                  onCommit={(result) => {
-                    if (result.actionId !== "confirm") {
-                      setDecisionEvent("Decision cancelled.");
-                      return;
-                    }
-
-                    const orderId =
-                      typeof result.payload?.orderId === "string"
-                        ? result.payload.orderId
-                        : `ORD-${Date.now()}`;
-                    const confirmedAt =
-                      typeof result.payload?.confirmedAt === "string"
-                        ? result.payload.confirmedAt
-                        : new Date().toISOString();
-
-                    setOrderChoice({
-                      action: "confirm",
-                      orderId,
-                      confirmedAt,
-                    });
-                    setDecisionEvent(`Committed decision envelope: ${orderId}`);
-                  }}
-                />
-              </ToolUI.Actions>
-            )}
-          </div>
-        </ToolUI>
+    <div className="not-prose grid gap-6">
+      <div className="flex flex-col gap-2">
+        <h4 className="text-base font-semibold">
+          OptionList uses <code>selectionActions</code>
+        </h4>
+        <OptionList
+          id="action-centric-option-list"
+          selectionMode="single"
+          options={[
+            {
+              id: "merge",
+              label: "Merge duplicates",
+              description: "Combine records and preserve all unique fields.",
+            },
+            {
+              id: "keep",
+              label: "Keep separate",
+              description: "Leave both records untouched.",
+            },
+            {
+              id: "review",
+              label: "Review manually",
+              description: "Open each pair for manual confirmation.",
+            },
+          ]}
+          choice={optionChoice}
+          selectionActions={[
+            { id: "cancel", label: "Clear", variant: "ghost" },
+            { id: "confirm", label: "Confirm Selection", variant: "default" },
+          ]}
+          onConfirm={(selection) => {
+            setOptionChoice(selection);
+            setOptionEvent(`Selection committed: ${formatSelection(selection)}`);
+          }}
+          onSelectionAction={(actionId) => {
+            setOptionEvent(`OptionList action fired: ${actionId}`);
+          }}
+        />
         <div className="flex items-center gap-2">
-          <p className="text-muted-foreground text-xs">{decisionEvent}</p>
-          {orderChoice && (
+          <p className="text-muted-foreground text-xs">{optionEvent}</p>
+          {optionChoice !== undefined && (
             <Button
               size="sm"
               variant="ghost"
               onClick={() => {
-                setOrderChoice(undefined);
-                setDecisionEvent("Decision reset for demo.");
+                setOptionChoice(undefined);
+                setOptionEvent("Selection reset for demo.");
               }}
             >
-              Reset decision
+              Reset
             </Button>
           )}
         </div>
-      </section>
+      </div>
 
-      <section className="flex flex-col gap-4">
-        <h3 className="text-xl font-semibold tracking-tight">
-          Action-Centric Components (Exception Class)
-        </h3>
-        <p className="text-muted-foreground text-sm">
-          These components keep actions in their own API because action handling
-          is part of their core interaction model.
-        </p>
-        <div className="grid gap-6">
-          <div className="flex flex-col gap-2">
-            <h4 className="text-base font-semibold">
-              OptionList uses <code>selectionActions</code>
-            </h4>
-            <OptionList
-              id="action-centric-option-list"
-              selectionMode="single"
-              options={[
-                {
-                  id: "merge",
-                  label: "Merge duplicates",
-                  description: "Combine records and preserve all unique fields.",
-                },
-                {
-                  id: "keep",
-                  label: "Keep separate",
-                  description: "Leave both records untouched.",
-                },
-                {
-                  id: "review",
-                  label: "Review manually",
-                  description: "Open each pair for manual confirmation.",
-                },
-              ]}
-              choice={optionChoice}
-              selectionActions={[
-                { id: "cancel", label: "Clear", variant: "ghost" },
-                { id: "confirm", label: "Confirm Selection", variant: "default" },
-              ]}
-              onConfirm={(selection) => {
-                setOptionChoice(selection);
-                setOptionEvent(`Selection committed: ${formatSelection(selection)}`);
-              }}
-              onSelectionAction={(actionId) => {
-                setOptionEvent(`OptionList action fired: ${actionId}`);
-              }}
-            />
-            <div className="flex items-center gap-2">
-              <p className="text-muted-foreground text-xs">{optionEvent}</p>
-              {optionChoice !== undefined && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => {
-                    setOptionChoice(undefined);
-                    setOptionEvent("Selection reset for demo.");
-                  }}
-                >
-                  Reset selection
-                </Button>
-              )}
-            </div>
-          </div>
+      <div className="flex flex-col gap-2">
+        <h4 className="text-base font-semibold">
+          ParameterSlider uses <code>adjustmentActions</code>
+        </h4>
+        <ParameterSlider
+          id="action-centric-parameter-slider"
+          sliders={[
+            {
+              id: "exposure",
+              label: "Exposure",
+              min: -2,
+              max: 2,
+              step: 0.1,
+              value: 0.2,
+              unit: " EV",
+              precision: 1,
+            },
+            {
+              id: "contrast",
+              label: "Contrast",
+              min: -50,
+              max: 50,
+              step: 1,
+              value: 12,
+              unit: "%",
+            },
+          ]}
+          values={sliderValues}
+          onChange={setSliderValues}
+          adjustmentActions={[
+            { id: "reset", label: "Reset", variant: "ghost" },
+            { id: "apply", label: "Apply Adjustments", variant: "default" },
+          ]}
+          onAdjustmentAction={(actionId, values) => {
+            if (actionId !== "apply") return;
+            const summary = values
+              .map((value) => `${value.id}: ${value.value}`)
+              .join(", ");
+            setSliderEvent(`Applied values: ${summary}`);
+          }}
+        />
+        <p className="text-muted-foreground text-xs">{sliderEvent}</p>
+      </div>
 
-          <div className="flex flex-col gap-2">
-            <h4 className="text-base font-semibold">
-              ParameterSlider uses <code>adjustmentActions</code>
-            </h4>
-            <ParameterSlider
-              id="action-centric-parameter-slider"
-              sliders={[
-                {
-                  id: "exposure",
-                  label: "Exposure",
-                  min: -2,
-                  max: 2,
-                  step: 0.1,
-                  value: 0.2,
-                  unit: " EV",
-                  precision: 1,
-                },
-                {
-                  id: "contrast",
-                  label: "Contrast",
-                  min: -50,
-                  max: 50,
-                  step: 1,
-                  value: 12,
-                  unit: "%",
-                },
-              ]}
-              values={sliderValues}
-              onChange={setSliderValues}
-              adjustmentActions={[
-                { id: "reset", label: "Reset", variant: "ghost" },
-                { id: "apply", label: "Apply Adjustments", variant: "default" },
-              ]}
-              onAdjustmentAction={(actionId, values) => {
-                if (actionId !== "apply") return;
-                const summary = values
-                  .map((value) => `${value.id}: ${value.value}`)
-                  .join(", ");
-                setSliderEvent(`Applied values: ${summary}`);
-              }}
-            />
-            <p className="text-muted-foreground text-xs">{sliderEvent}</p>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <h4 className="text-base font-semibold">
-              PreferencesPanel uses <code>formActions</code>
-            </h4>
-            <PreferencesPanel
-              id="action-centric-preferences-panel"
-              title="Notification Preferences"
-              sections={preferencesSections}
-              formActions={[
-                { id: "cancel", label: "Cancel", variant: "ghost" },
-                { id: "save", label: "Save Preferences", variant: "default" },
-              ]}
-              onFormAction={(actionId, value) => {
-                if (actionId === "save") {
-                  setSavedPreferences(value);
-                  setPreferencesEvent("Preferences saved.");
-                  return;
-                }
-                if (actionId === "cancel") {
-                  setSavedPreferences(null);
-                  setPreferencesEvent("Edit cancelled.");
-                }
-              }}
-            />
-            <p className="text-muted-foreground text-xs">{preferencesEvent}</p>
-            <pre className="bg-muted overflow-auto rounded-md p-3 text-xs leading-relaxed">
-              {savedPreferences
-                ? JSON.stringify(savedPreferences, null, 2)
-                : "No saved preferences yet."}
-            </pre>
-          </div>
-        </div>
-      </section>
+      <div className="flex flex-col gap-2">
+        <h4 className="text-base font-semibold">
+          PreferencesPanel uses <code>formActions</code>
+        </h4>
+        <PreferencesPanel
+          id="action-centric-preferences-panel"
+          title="Notification Preferences"
+          sections={preferencesSections}
+          formActions={[
+            { id: "cancel", label: "Cancel", variant: "ghost" },
+            { id: "save", label: "Save Preferences", variant: "default" },
+          ]}
+          onFormAction={(actionId, value) => {
+            if (actionId === "save") {
+              setSavedPreferences(value);
+              setPreferencesEvent("Preferences saved.");
+              return;
+            }
+            if (actionId === "cancel") {
+              setSavedPreferences(null);
+              setPreferencesEvent("Edit cancelled.");
+            }
+          }}
+        />
+        <p className="text-muted-foreground text-xs">{preferencesEvent}</p>
+        <pre className="bg-muted overflow-auto rounded-md p-3 text-xs leading-relaxed">
+          {savedPreferences
+            ? JSON.stringify(savedPreferences, null, 2)
+            : "No saved preferences yet."}
+        </pre>
+      </div>
     </div>
   );
 }

--- a/app/docs/actions/content.mdx
+++ b/app/docs/actions/content.mdx
@@ -1,77 +1,140 @@
 import { DocsHeader } from "../_components/docs-header";
-import { ActionsExamples } from "./actions-examples";
+import {
+  ActionFlowCommitVisual,
+  ActionFlowRenderVisual,
+  ActionFlowRuntimeHandleVisual,
+  ActionFlowToolCallVisual,
+  ActionFlowUserActionVisual,
+  ActionCentricExceptionsExample,
+  DecisionSurfaceExample,
+  DisplaySurfaceLocalActionsExample,
+} from "./actions-examples";
 
 <DocsHeader
   title="Actions"
-  description="How Tool UI actions work, when to use each action pattern, and why some components intentionally use dedicated action props."
+  description="Action model basics."
   mdxPath="app/docs/actions/content.mdx"
 />
 
-Tool UI actions are how a user turns a rendered tool UI into behavior.
-
-If you're new to tool calling, this page gives you the mental model first, then the implementation patterns.
+Tool UI actions are how a user turns a rendered tool UI into behavior. If you're new to tool calling, this page gives you the mental model first, then the implementation patterns.
 
 ## Start Here
 
-In Tool UI, a typical interaction looks like this:
+<Steps>
 
-1. The model calls a tool with arguments.
-2. Your app renders a Tool UI component from those arguments.
-3. The user clicks an action.
-4. Your runtime handles the action.
-5. If the action is consequential, your runtime commits a result that can be rendered as a receipt state.
+<Step title="The model calls a tool">
 
-This is why action modeling matters: it defines where behavior lives and how outcomes become durable.
+The model chooses a tool and sends structured arguments.
 
-## The Two Standard Action Surfaces
+<ActionFlowToolCallVisual />
 
-Most display-first components follow this split:
+```ts
+tools: {
+  getExpenses: tool({
+    description: "Return travel expenses for a month",
+    execute: async ({ month }) => ({ id: "expenses-jan", month }),
+  }),
+}
+```
 
-- `ToolUI.LocalActions`: for local/runtime side effects. These are non-consequential.
-- `ToolUI.DecisionActions`: for consequential choices. These produce a typed decision envelope and commit outcome state.
+</Step>
 
-For display-first components, keep the data surface display-only and compose actions as siblings with:
+<Step title="Your app renders a Tool UI surface">
 
-- `ToolUI`
-- `ToolUI.Surface`
-- `ToolUI.Actions`
+The returned args are parsed and rendered as a display surface.
 
-## Which Pattern Should I Use?
+<ActionFlowRenderVisual />
 
-| Scenario | Use | Why |
-|---|---|---|
-| Display-first component with utility actions (export/open/copy) | `ToolUI.LocalActions` | Side effects stay local and do not require durable decision state |
-| Display-first component with consequential user decision | `ToolUI.DecisionActions` | Decisions are explicit, typed, and commit-ready |
-| Action-centric component where behavior is intrinsic to the component itself | Dedicated component props | The action logic is part of the component state model, not sibling chrome |
+```tsx
+render: createResultToolRenderer({
+  safeParse: safeParseSerializableDataTable,
+  render: (parsed) => <DataTable {...parsed} />,
+})
+```
 
-## Important Exception: Action-Centric Components
+</Step>
 
-Some Tool UI components are intentionally action-centric, so they keep dedicated action props.
+<Step title="The user triggers an action">
 
-| Component | Dedicated action props | Why |
-|---|---|---|
-| `OptionList` | `selectionActions`, `onSelectionAction`, `onBeforeSelectionAction` | Selection and confirmation are intrinsic to the list workflow |
-| `ParameterSlider` | `adjustmentActions`, `onAdjustmentAction`, `onBeforeAdjustmentAction` | Apply/reset behavior is part of adjustment semantics |
-| `PreferencesPanel` | `formActions`, `onFormAction`, `onBeforeFormAction` | Save/cancel is part of form lifecycle and dirty-state handling |
+The user clicks an action control associated with the surface.
 
-These components are intentionally not forced into sibling `LocalActions` or `DecisionActions`.
+<ActionFlowUserActionVisual />
 
-## Where `addResult(...)` Belongs
+```tsx
+const localActions = [{ id: "export-csv", label: "Export CSV" }];
 
-- `ToolUI.LocalActions`: never commit result state from these handlers.
-- `ToolUI.DecisionActions`: produce envelope in decision handler, then commit in the commit step.
-- Action-centric components: commit from their explicit confirm/apply/save flow in your tool renderer.
+async function handleLocalAction(actionId: string) {
+  // side effects only
+}
+```
 
-## Visual Examples
+</Step>
 
-<ActionsExamples />
+<Step title="The runtime handles the action">
 
-## Legacy Mapping
+Your action handler runs side effects (navigation, export, API call, etc.).
 
-If you are migrating older code:
+<ActionFlowRuntimeHandleVisual />
 
-| Legacy API | Current API |
+```ts
+async function handleLocalAction(actionId: string) {
+  if (actionId === "export-csv") await exportCsv();
+  if (actionId === "open-report") router.push("/reports/monthly");
+}
+```
+
+</Step>
+
+<Step title="For consequential actions, commit decision outcome">
+
+If the action is consequential, commit a durable outcome (typically via `addResult(...)` in your renderer runtime).
+
+<ActionFlowCommitVisual />
+
+```tsx
+const decision = createDecisionResult({
+  decisionId: "order-123",
+  action: { id: "confirm", label: "Purchase" },
+});
+
+await addResult?.(decision);
+```
+
+</Step>
+
+</Steps>
+
+## Action Surfaces
+
+The standard split is:
+
+- `ToolUI.LocalActions`: non-consequential runtime side effects.
+- `ToolUI.DecisionActions`: consequential choices that produce commit-ready decision envelopes.
+
+### Display Components + LocalActions
+
+For display-first components, keep rendering and actions separate: the display component goes inside `ToolUI.Surface`, and local actions go inside sibling `ToolUI.Actions`.
+
+<DisplaySurfaceLocalActionsExample />
+
+`LocalActions` handlers should not commit durable result state.
+
+### Decision Components + DecisionActions
+
+When user intent is consequential (approve, confirm, purchase, publish, delete), use `DecisionActions`. This makes decision payload shape explicit and commit behavior auditable.
+
+<DecisionSurfaceExample />
+
+`DecisionActions` handlers should return a typed envelope, then commit in the commit phase.
+
+## Action-Centric Components (Intentional Exception)
+
+Some components are action-centric by design. Their action handling is part of component semantics, so they keep dedicated action props instead of sibling surfaces.
+
+| Component | Dedicated action props |
 |---|---|
-| `responseActions` on display-first components | Sibling `ToolUI.LocalActions` or `ToolUI.DecisionActions` |
-| `onResponseAction` / `onBeforeResponseAction` | `ToolUI.LocalActions` handlers, `ToolUI.DecisionActions` handlers, or dedicated outlier handlers |
-| `/docs/local-actions` and `/docs/response-actions` | `/docs/actions` |
+| `OptionList` | `selectionActions`, `onSelectionAction`, `onBeforeSelectionAction` |
+| `ParameterSlider` | `adjustmentActions`, `onAdjustmentAction`, `onBeforeAdjustmentAction` |
+| `PreferencesPanel` | `formActions`, `onFormAction`, `onBeforeFormAction` |
+
+<ActionCentricExceptionsExample />

--- a/app/docs/actions/page.tsx
+++ b/app/docs/actions/page.tsx
@@ -4,8 +4,7 @@ import { DocsArticle } from "../_components/docs-article";
 
 export const metadata: Metadata = {
   title: "Actions",
-  description:
-    "Learn the Tool UI action model: sibling LocalActions and DecisionActions for display-first components, plus dedicated action props for action-centric components.",
+  description: "Action model basics.",
 };
 
 export const revalidate = 3600;


### PR DESCRIPTION
## Summary\n- rewrite the Actions docs page for first-time Tool UI readers\n- add a clear decision framework for LocalActions vs DecisionActions\n- explicitly document action-centric exception components (OptionList, ParameterSlider, PreferencesPanel)\n- expand interactive visual examples to demonstrate standard and exception patterns\n\n## Notes\n- this PR focuses on docs and example behavior in the docs site\n- no production runtime behavior outside docs/examples was changed