### PR TITLE
docs: rewrite core documentation pages

### DIFF
--- a/app/docs/advanced/content.mdx
+++ b/app/docs/advanced/content.mdx
@@ -148,3 +148,119 @@ const parsed = safeParseSerializableX(resultOrArgs);
 if (!parsed) return null;
 return <X {...parsed} />;
 ```
+
+## Frontend tools (interactive Tool UIs)
+
+Some Tool UIs — especially decision surfaces like OptionList — are best modeled as **frontend tools**: the model calls a tool whose arguments are the component props, and your UI calls `addResult(...)` after the user confirms a choice. The result feeds back into the conversation as a tool result.
+
+If you're using `AssistantChatTransport`, it forwards **system instructions** and **registered tools** in the request body. Your `/api/chat` route needs to read and forward them, otherwise the model won't see your frontend tools.
+
+```ts title="app/api/chat/route.ts"
+import { openai } from "@ai-sdk/openai";
+import {
+  streamText,
+  convertToModelMessages,
+  jsonSchema,
+  type UIMessage,
+  type JSONSchema7,
+} from "ai";
+
+type ForwardedTools = Record<
+  string,
+  { description?: string; parameters: JSONSchema7 }
+>;
+
+function toStreamTextTools(tools?: ForwardedTools) {
+  if (!tools) return undefined;
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => [
+      name,
+      {
+        ...(tool.description ? { description: tool.description } : {}),
+        inputSchema: jsonSchema(tool.parameters),
+      },
+    ]),
+  );
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as {
+    messages: UIMessage[];
+    system?: string;
+    tools?: ForwardedTools;
+  };
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages: await convertToModelMessages(body.messages),
+    system: body.system,
+    tools: toStreamTextTools(body.tools),
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+### Register a frontend tool
+
+Register the tool on the client so it gets forwarded by `AssistantChatTransport`, and render a Tool UI when it's called.
+
+```tsx
+"use client";
+
+import { type Toolkit } from "@assistant-ui/react";
+import { OptionList } from "@/components/tool-ui/option-list";
+import {
+  safeParseSerializableOptionList,
+  SerializableOptionListSchema,
+} from "@/components/tool-ui/option-list/schema";
+import { createArgsToolRenderer } from "@/components/tool-ui/shared";
+
+export const toolkit: Toolkit = {
+  selectFormat: {
+    // description and parameters are forwarded to the model.
+    description: "Ask the user to choose an output format.",
+    parameters: SerializableOptionListSchema,
+    // For frontend tools, use createArgsToolRenderer (parses args, not result).
+    render: createArgsToolRenderer({
+      safeParse: safeParseSerializableOptionList,
+      idPrefix: "format-selection",
+      render: (parsedArgs, { result, addResult }) => {
+        if (result) {
+          // After the user confirms, render the receipt state.
+          return (
+            <OptionList {...parsedArgs} value={undefined} choice={result} />
+          );
+        }
+
+        return (
+          <OptionList
+            {...parsedArgs}
+            value={undefined}
+            onConfirm={(selection) => addResult?.(selection)}
+          />
+        );
+      },
+    }),
+  },
+};
+```
+
+Register this toolkit with `Tools({ toolkit })` under `<AssistantRuntimeProvider>` so the tool definition and renderer are both forwarded by `AssistantChatTransport`.
+
+### Auto-continue after `addResult(...)`
+
+If you want the assistant to continue automatically after the user confirms (instead of waiting for the next user message), enable AI SDK's auto-resubmit behavior:
+
+```tsx
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
+import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+
+const runtime = useChatRuntime({
+  transport: new AssistantChatTransport({ api: "/api/chat" }),
+  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+});
+```

--- a/app/docs/overview/content.mdx
+++ b/app/docs/overview/content.mdx
@@ -1,10 +1,13 @@
 import { DocsHeader } from "../_components/docs-header";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { FlaskConical } from "lucide-react";
+import { MockThread, MockMessage } from "../_components/mock-thread";
+import { LinkPreview } from "@/components/tool-ui/link-preview";
+import { OptionList } from "@/components/tool-ui/option-list";
 
 <DocsHeader
   title="Overview"
-  description="A React component framework for conversation-native UIs."
+  description="Rich, interactive UI components for AI tool calls."
   mdxPath="app/docs/overview/content.mdx"
 />
 
@@ -20,53 +23,145 @@ import { FlaskConical } from "lucide-react";
   </AlertDescription>
 </Alert>
 
-Tool UI is a React component framework for **conversation‑native** UIs.  
-Tools return **JSON**; Tool UI renders it as **inline, narrated, referenceable** surfaces.
+When an AI assistant calls a tool, it usually returns plain text or raw JSON. The user sees a wall of data they have to parse themselves.
 
-## At a glance
+Tool UI turns those tool results into **real React components** — cards, tables, option lists — that render inline in the conversation and let users interact without leaving the chat.
 
-- **Conversation‑native components** that live _inside messages_, optimized for chat width and scroll.
-- **Schema‑first rendering**: every surface is driven by a serializable schema with stable IDs.
-- **Assistant‑anchored**: the assistant introduces, interprets, and closes each surface.
-- **Stack‑agnostic**: works with any LLM/provider and orchestration layer.
+<div className="mx-auto mt-8 grid max-w-2xl gap-6 md:grid-cols-2">
+  <MockThread caption="Without Tool UI">
+    <MockMessage role="user">Find me a link to the Tailwind docs</MockMessage>
+    <MockMessage role="assistant">
+      <span className="text-foreground text-sm">
+        {"Here's the link to the Tailwind CSS documentation:"}
+      </span>
+      <pre className="bg-muted text-muted-foreground mt-2 overflow-x-auto rounded-lg p-3 font-mono text-xs">
+{`{
+  "href": "https://tailwindcss.com/docs",
+  "title": "Tailwind CSS",
+  "description": "Rapidly build modern websites without ever leaving your HTML."
+}`}
+      </pre>
+    </MockMessage>
+  </MockThread>
 
-## Where it fits
+  <MockThread caption="With Tool UI">
+    <MockMessage role="user">Find me a link to the Tailwind docs</MockMessage>
+    <MockMessage role="assistant">
+      <span className="text-foreground text-sm">
+        {"Found it."}
+      </span>
+      <div className="mt-3">
+        <LinkPreview
+          id="lp-tailwind"
+          href="https://tailwindcss.com/docs"
+          title="Tailwind CSS"
+          description="Rapidly build modern websites without ever leaving your HTML."
+          domain="tailwindcss.com"
+          favicon="https://tailwindcss.com/favicons/favicon-32x32.png"
+        />
+      </div>
+    </MockMessage>
+  </MockThread>
+</div>
 
-[Radix](https://www.radix-ui.com/)/[shadcn](https://ui.shadcn.com/) (primitives) → **Tool UI** (conversation‑native components & schema) → [AI SDK](https://ai-sdk.dev/) / [LangGraph](https://langchain-ai.github.io/langgraphjs/) / etc. (LLM orchestration)
+Same data, different experience. The left side dumps JSON the user has to read. The right side renders a clickable card that looks and behaves like a native part of the conversation.
 
-## Who it’s for
+## What is tool calling?
 
-- **React devs & design engineers** building LLM chat apps.
-- Teams who want **predictable, accessible** UI that the assistant can **reference** (“the second row”).
-- Anyone who wants **typed, schema‑validated** tool outputs instead of brittle HTML strings.
+Most AI chat applications let the model do more than just generate text. Through **tool calling** (sometimes called "function calling"), you define functions the model can invoke — searching a database, fetching a URL, running a calculation — and the model decides when to call them based on the conversation.
 
-## Why Tool UI
+The model sends structured arguments. Your server executes the function and returns a result. Normally, that result is plain text or JSON that gets passed back into the conversation as-is.
 
-- **Predictable rendering**: Tools emit schema‑validated JSON; components render consistently across themes/devices.
-- **Built for chat**: Mobile‑first, glanceable, minimal chrome; no in‑message navigation flows.
-- **Developer control**: Components render; **your app** owns side effects via callbacks/server actions.
-- **Type safety**: Serializable schemas on the server, parsers on the client; works great with AI SDK [`InferUITools`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/infer-ui-tools).
-- **Lifecycle aware**: Clear phases from invocation through receipt; supersession behavior is explicit.
+Tool UI is about what happens next: **rendering those results as interactive UI**.
 
-## Mental model
+## What if tool results could render UI?
 
-See **[UI Guidelines](/docs/design-guidelines)** for the full philosophy. Quick summary:
+Here's the key idea. When a tool returns JSON that matches a known **schema**, your app can render a rich component instead of showing raw data.
 
-- **5 Fundamentals:** One intent · Inline · Schema‑first · Assistant‑anchored · Lifecycle aware
-- **Roles:** `information`, `decision`, `control`, `state`, `composite`
-- **Lifecycle:** `invocation → output‑pending → interactive → committing → receipt → errored`
-- **Conversation coherence:** Every important action ↔ one **canonical sentence**; side effects yield a **durable receipt** (status, summary, identifiers, timestamp)
+Every Tool UI component has a corresponding schema — a Zod definition that describes the shape of the data it needs. When the tool result matches, the component renders. When it doesn't, parsing fails safely and nothing renders.
+
+```ts title="Tool output → Component"
+// The tool returns structured JSON...
+{
+  id: "lp-1",
+  href: "https://tailwindcss.com/docs",
+  title: "Tailwind CSS",
+  description: "Rapidly build modern websites..."
+}
+
+// ...that matches the LinkPreview schema → renders as a card
+```
+
+This is **schema-first rendering**: the data contract between server and client is explicit, typed, and validated. No brittle string parsing. No hoping the model formats things correctly.
+
+## What if that UI could be interactive?
+
+Some tool UIs just display information — a link preview, a chart, a code block. But others let users **make decisions** that feed back into the conversation.
+
+<div className="mx-auto max-w-sm">
+  <MockThread caption="An interactive tool UI">
+    <MockMessage role="user">Help me pick a database for the new project</MockMessage>
+    <MockMessage role="assistant">
+      <span className="text-foreground text-sm">
+        {"Based on your requirements, here are some options:"}
+      </span>
+      <div className="mt-3">
+        <OptionList
+          selectionMode="single"
+          choice="postgres"
+          options={[
+            {
+              id: "postgres",
+              label: "PostgreSQL",
+              description: "Best for relational data with complex queries",
+            },
+            {
+              id: "sqlite",
+              label: "SQLite",
+              description: "Simple, embedded, great for single-server apps",
+            },
+            {
+              id: "dynamo",
+              label: "DynamoDB",
+              description: "Fully managed NoSQL, scales automatically",
+            },
+          ]}
+        />
+      </div>
+    </MockMessage>
+    <MockMessage role="assistant">
+      <span className="text-foreground text-sm">
+        Good choice. PostgreSQL gives you strong typing, JSON support, and a
+        mature ecosystem. Want me to set up the schema?
+      </span>
+    </MockMessage>
+  </MockThread>
+</div>
+
+The user selects an option, and the choice flows back to the assistant as a **tool result**. The assistant can then continue the conversation with that context. The selected state stays visible as a **receipt** — a permanent record of the decision.
+
+This is the [actions](/docs/actions) model: user interactions on tool UIs that produce side effects and durable records.
+
+## Where Tool UI fits
+
+Tool UI sits between your design system and your LLM orchestration layer:
+
+[Radix](https://www.radix-ui.com/)/[shadcn](https://ui.shadcn.com/) (design primitives) → **Tool UI** (conversation-native components) → [AI SDK](https://ai-sdk.dev/) / [LangGraph](https://langchain-ai.github.io/langgraphjs/) / etc. (LLM orchestration)
+
+- **Radix / shadcn** provide the base UI primitives (buttons, dialogs, inputs).
+- **Tool UI** provides components designed for chat — inline cards, tables, option lists, approval flows — with schemas that map to tool outputs.
+- **AI SDK / LangGraph** handle the model communication, streaming, and tool execution.
+
+Tool UI doesn't replace your design system. It builds on it. Components use shadcn primitives internally and follow your theme.
 
 ## How it works
 
-The assistant calls a tool, the tool returns JSON matching a schema, and the UI renders inline.
-
 <Mermaid chart={`
 flowchart LR
-    A["Assistant calls tool"] --> B["JSON output"]
-    B --> C["‹Component /›"]
+    A["Assistant calls tool"] --> B["Tool returns JSON"]
+    B --> C["Schema match → Component renders"]
     C --> D["User interacts"]
-    D --> E["App handles effects"]
+    D --> E["Result flows back"]
 
     style A fill:#8b5cf6,stroke:#7c3aed,stroke-width:2px,color:#fff
     style B fill:#10b981,stroke:#059669,stroke-width:2px,color:#fff
@@ -76,17 +171,19 @@ flowchart LR
 
 `} />
 
+1. **The assistant calls a tool.** Based on the conversation, the model decides to invoke a tool you've defined (e.g., `previewLink`, `searchFlights`).
+2. **The tool returns JSON.** Your server-side function executes and returns structured data matching an `outputSchema`.
+3. **The schema matches — a component renders.** On the client, a registered renderer parses the JSON against the component's schema. If it matches, the component renders inline in the chat message.
+4. **The user interacts.** For display components, this is the end. For interactive components (decisions, approvals), the user takes an action.
+5. **The result flows back.** The user's choice is sent back to the assistant as a tool result via `addResult`, continuing the conversation.
+
 ### Minimal example
 
-**Server side:** Define a tool that returns schema-validated JSON.
+Here's the end-to-end wiring. The server defines a tool with a typed output schema. The client registers a renderer that maps that output to a component.
 
-**What this demonstrates:**
+**Server — define a tool that returns structured data:**
 
-- `SerializableLinkPreviewSchema` enforces type-safe output
-- Actions have both UI labels and canonical sentences for conversation coherence
-- The schema guarantees the frontend receives reconstructable, addressable data
-
-```ts title="Server: define a tool with an output schema"
+```ts title="app/api/chat/route.ts"
 import { streamText, tool, convertToModelMessages } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { z } from "zod";
@@ -102,8 +199,10 @@ export async function POST(req: Request) {
       previewLink: tool({
         description: "Show a preview card for a URL",
         inputSchema: z.object({ url: z.url() }),
+        // outputSchema tells the AI SDK what shape the result will have
         outputSchema: SerializableLinkPreviewSchema,
         async execute({ url }) {
+          // Fetch metadata and return structured data
           return {
             id: "link-preview-1",
             href: url,
@@ -120,16 +219,11 @@ export async function POST(req: Request) {
 }
 ```
 
-**Client side:** Register the component and let assistant-ui handle rendering.
+The `outputSchema` is a Zod schema imported from the Tool UI component. It ensures the data your tool returns is exactly what the component expects.
 
-**What this demonstrates:**
+**Client — register the component renderer:**
 
-- `Tools({ toolkit })` registers tool renderers once
-- `safeParseSerializableLinkPreview` is the render gate: return `null` until the full payload parses
-- `useAui({ tools: ... })` makes tool UIs available to the runtime
-- assistant-ui manages the runtime, streaming, and tool call lifecycle
-
-```tsx title="Client: render with assistant-ui"
+```tsx title="app/page.tsx"
 "use client";
 import {
   AssistantRuntimeProvider,
@@ -141,73 +235,44 @@ import {
   useChatRuntime,
   AssistantChatTransport,
 } from "@assistant-ui/react-ai-sdk";
-import {
-  LinkPreview,
-} from "@/components/tool-ui/link-preview";
+import { LinkPreview } from "@/components/tool-ui/link-preview";
 import { safeParseSerializableLinkPreview } from "@/components/tool-ui/link-preview/schema";
 
+// Register a renderer for each tool that should display a component
 const toolkit: Toolkit = {
   previewLink: {
     type: "backend",
     render: ({ result }) => {
-      const parsedResult = safeParseSerializableLinkPreview(result);
-
-      // Tool UI renderers should mount only when the full payload parses.
-      if (!parsedResult) {
-        return null;
-      }
-      return (
-        <>
-          <LinkPreview {...parsedResult} maxWidth="420px" />
-        </>
-      );
+      const parsed = safeParseSerializableLinkPreview(result);
+      if (!parsed) return null; // Wait for full payload before rendering
+      return <LinkPreview {...parsed} />;
     },
   },
 };
 
 export default function App() {
+  // Connect to your API route
   const runtime = useChatRuntime({
     transport: new AssistantChatTransport({ api: "/api/chat" }),
   });
+
+  // Make tool renderers available to the runtime
   const aui = useAui({ tools: Tools({ toolkit }) });
 
   return (
     <AssistantRuntimeProvider runtime={runtime} aui={aui}>
-      {/* your <Thread /> component here */}
+      {/* Your chat thread component */}
     </AssistantRuntimeProvider>
   );
 }
 ```
 
-## Anatomy of a surface
-
-Every Tool UI surface is addressable and reconstructable. Here's the common schema structure:
-
-**What this shows:**
-
-- `id` makes the tool UI referenceable by the assistant ("the link preview above")
-- `role` declares the primary purpose (information, decision, control, state, or composite)
-- `actions` with `sentence` fields let the assistant speak about user choices
-- `receipt` provides durable proof of side effects with timestamps and identifiers
-
-```ts
-{
-  id: string;                     // stable identifier for this rendering
-  role: "information"|"decision"|"control"|"state"|"composite";
-  actions?: Array<{ id: string; label: string; sentence: string }>;
-  // optional receipt after side effects:
-  receipt?: {
-    outcome: "success"|"partial"|"failed"|"cancelled";
-    summary: string;
-    identifiers?: Record<string, string>;
-    at: string;                   // ISO timestamp
-  };
-}
-```
+The `toolkit` maps tool names to renderers. Each renderer receives the tool's result, parses it against the component's schema with `safeParse`, and renders the component when the data is valid. `useAui` and `Tools` wire everything into the assistant-ui runtime.
 
 ## Next steps
 
-- **[Quick Start](/docs/quick-start)**: Wire your first Tool UI
-- **[Agent Skills](/docs/agent-skills)**: Install and use the Tool UI skill
-- **[UI Guidelines](/docs/design-guidelines)**: Patterns, roles, lifecycle, receipts
-- **[Gallery](/docs/gallery)**: Browse all components
+- **[Quick Start](/docs/quick-start)** — Set up a working tool UI from scratch
+- **[Actions](/docs/actions)** — How interactive tool UIs feed decisions back to the assistant
+- **[Receipts](/docs/receipts)** — How to show durable records of user decisions
+- **[Gallery](/docs/gallery)** — Browse all available components
+- **[UI Guidelines](/docs/design-guidelines)** — Design philosophy and patterns

--- a/app/docs/quick-start/content.mdx
+++ b/app/docs/quick-start/content.mdx
@@ -4,7 +4,7 @@ import { Bot } from "lucide-react";
 
 <DocsHeader
   title="Quick Start"
-  description="Get Tool UI working in your app in minutes."
+  description="Add your first Tool UI to a chat app."
   mdxPath="app/docs/quick-start/content.mdx"
 />
 
@@ -19,55 +19,76 @@ import { Bot } from "lucide-react";
   </AlertDescription>
 </Alert>
 
-## Setup
+This guide walks you through adding a Tool UI component to a chat app. By the end you'll have an assistant that renders a rich link preview card instead of dumping raw JSON into the conversation.
+
+**What you'll build:** A backend tool that fetches link metadata, and a frontend renderer that turns the JSON response into an interactive LinkPreview card — all wired together through [assistant-ui](https://www.assistant-ui.com/).
+
+## Install
 
 <Steps>
 
-<Step title="Initialize assistant-ui">
+<Step title="Set up assistant-ui">
 
-Set up the assistant-ui runtime provider that manages the connection between your frontend and backend. This handles message streaming, tool execution, and state management.
+[assistant-ui](https://www.assistant-ui.com/) is the React runtime that manages chat state, message streaming, and tool rendering. If you already have it set up, skip to [Step 2](#add-a-tool-ui-component).
 
-**What this demonstrates:**
+The fastest way to start is with the CLI, which scaffolds a working chat app in a Next.js project:
 
-- `useChatRuntime` creates a runtime that connects to your backend API
-- `AssistantChatTransport` handles the communication protocol with your `/api/chat` endpoint
-- `AssistantRuntimeProvider` makes the runtime available to all child components
-
-```tsx
-"use client";
-import { AssistantRuntimeProvider } from "@assistant-ui/react";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
-
-function App() {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({ api: "/api/chat" }),
-  });
-
-  return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      {/* Your chat UI */}
-    </AssistantRuntimeProvider>
-  );
-}
+```sh
+npx assistant-ui@latest init
 ```
+
+Or install packages manually into an existing project:
+
+```sh
+pnpm add @assistant-ui/react @assistant-ui/react-ai-sdk ai @ai-sdk/openai zod
+```
+
+Add your OpenAI API key to `.env.local`:
+
+```env
+OPENAI_API_KEY=sk-...
+```
+
+Run `pnpm dev` and confirm you see a working chat interface before continuing.
 
 </Step>
 
+<Step title="Add a Tool UI component">
+
+Install the LinkPreview component from the Tool UI registry. This works exactly like installing any shadcn component — the CLI copies the source files into your project.
+
+First, make sure your `components.json` includes the `@tool-ui` registry. You may already have this if you used `assistant-ui init`:
+
+```json
+"registries": {
+  "@assistant-ui": "https://r.assistant-ui.com/{name}.json",
+  "@tool-ui": "https://tool-ui.com/r/{name}.json"
+}
+```
+
+Then install:
+
+```bash
+npx shadcn@latest add @tool-ui/link-preview
+```
+
+This copies `components/tool-ui/link-preview/` and `components/tool-ui/shared/` into your project. You own the code — modify it however you like.
+
+</Step>
+
+</Steps>
+
+## Wire it up
+
+Now that you have the runtime and the component, connect them: define a backend tool that returns structured data, then register a renderer that turns that data into the LinkPreview component.
+
+<Steps>
+
 <Step title="Define a backend tool">
 
-Create a tool on your server that the LLM can call. The tool returns structured JSON that matches a Tool UI component schema. Here we're creating a link preview tool that returns data for the LinkPreview component.
+Create (or update) your API route to include a tool the LLM can call. This tool accepts a URL, fetches metadata, and returns JSON matching the LinkPreview schema.
 
-**What this demonstrates:**
-
-- `SerializableLinkPreviewSchema` ensures your tool output matches the LinkPreview component's expected format
-- `id` identifies this rendering in the conversation
-- `safeParseSerializableLinkPreview` on the frontend gates rendering until the payload is complete
-- Your tool can fetch real data (APIs, databases) and return it in the component schema format
-
-```ts
+```ts title="app/api/chat/route.ts"
 import { streamText, tool, convertToModelMessages, jsonSchema } from "ai";
 import { openai } from "@ai-sdk/openai";
 
@@ -78,6 +99,7 @@ export async function POST(req: Request) {
     model: openai("gpt-4o"),
     messages: await convertToModelMessages(messages),
     tools: {
+      // The LLM decides when to call this tool based on the description.
       previewLink: tool({
         description: "Show a preview card for a URL",
         inputSchema: jsonSchema<{ url: string }>({
@@ -86,8 +108,9 @@ export async function POST(req: Request) {
           required: ["url"],
           additionalProperties: false,
         }),
+        // execute() runs on the server when the LLM calls the tool.
+        // It returns JSON that matches the LinkPreview component's schema.
         async execute({ url }) {
-          // In production, you'd fetch real metadata here
           return {
             id: "link-preview-1",
             href: url,
@@ -104,20 +127,17 @@ export async function POST(req: Request) {
 }
 ```
 
+When a user asks the assistant about a link, the LLM calls `previewLink` with a URL. The `execute` function runs on your server and returns the structured data. In a real app, you'd fetch actual metadata here (Open Graph tags, screenshots, etc.).
+
 </Step>
 
-<Step title="Register the Tool UI">
+<Step title="Register the renderer">
 
-Connect your backend tool to a frontend component. When the LLM calls the `previewLink` tool, assistant-ui will automatically render the LinkPreview component with the returned data.
+On the client, tell assistant-ui how to render the tool's output. When the LLM calls `previewLink`, the runtime receives the JSON result and passes it to the renderer you register here.
 
-**What this demonstrates:**
+```tsx title="app/page.tsx"
+"use client";
 
-- `Tools({ toolkit })` registers tool renderers in one place
-- `safeParseSerializableLinkPreview` is the render gate: no payload, no render (`return null`)
-- The toolkit key (`previewLink`) must match your backend tool name
-- `useAui({ tools: ... })` wires tool rendering into `AssistantRuntimeProvider`
-
-```tsx
 import {
   AssistantRuntimeProvider,
   Tools,
@@ -125,219 +145,76 @@ import {
   type Toolkit,
 } from "@assistant-ui/react";
 import {
-  LinkPreview,
-} from "@/components/tool-ui/link-preview";
-import { safeParseSerializableLinkPreview } from "@/components/tool-ui/link-preview/schema";
-import { createResultToolRenderer } from "@/components/tool-ui/shared";
-import {
   useChatRuntime,
   AssistantChatTransport,
 } from "@assistant-ui/react-ai-sdk";
+import { LinkPreview } from "@/components/tool-ui/link-preview";
+import { safeParseSerializableLinkPreview } from "@/components/tool-ui/link-preview/schema";
+import { createResultToolRenderer } from "@/components/tool-ui/shared";
 
+// Map backend tool names to frontend renderers.
+// The key "previewLink" must match the tool name in your API route.
 const toolkit: Toolkit = {
   previewLink: {
     type: "backend",
     render: createResultToolRenderer({
+      // Only render when the full payload is valid.
+      // While the LLM is still streaming, safeParse returns null → nothing renders.
       safeParse: safeParseSerializableLinkPreview,
-      render: (parsedResult) => (
-        <>
-            <LinkPreview {...parsedResult} maxWidth="420px" />
-        </>
-      ),
+      render: (parsed) => <LinkPreview {...parsed} />,
     }),
   },
 };
 
-function App() {
+export default function Page() {
+  // Connect to your /api/chat route.
   const runtime = useChatRuntime({
     transport: new AssistantChatTransport({ api: "/api/chat" }),
   });
+
+  // Register the toolkit so the runtime knows how to render tool results.
   const aui = useAui({ tools: Tools({ toolkit }) });
 
   return (
     <AssistantRuntimeProvider runtime={runtime} aui={aui}>
-      <Thread />
+      {/* Your chat thread component */}
     </AssistantRuntimeProvider>
   );
 }
 ```
 
-That's it! When a user asks the assistant to preview a link, it will call your tool and render the LinkPreview component.
+Run `pnpm dev`, then ask the assistant to "preview https://example.com." Instead of raw JSON, you'll see a styled LinkPreview card in the conversation.
 
 </Step>
 
 </Steps>
 
-## Installation
+## Add more components
 
-The fastest way to get started is with the assistant-ui CLI:
+To install another component, repeat the same pattern:
 
-```sh
-npx assistant-ui@latest init
-```
-
-Or install packages manually if you prefer to configure yourself:
-
-```sh
-pnpm add @assistant-ui/react @assistant-ui/react-ai-sdk ai @ai-sdk/openai zod
-```
-
-Add your OpenAI API key to your environment variables:
-
-```env
-OPENAI_API_KEY=sk-...
-```
-
-### Install Tool UI components via the shadcn registry
-
-Tool UI publishes every component as a shadcn registry entry under `https://tool-ui.com/r/<component>.json`. Each JSON snippet bundles component code plus the shared helpers from `components/tool-ui/shared`, and expects your app's existing shadcn `@/lib/utils` helper.
-
-1. Make sure your `components.json` lists the `@tool-ui` registry alongside the default `@assistant-ui` registry so the CLI knows where to fetch the files. This repo already has the necessary entry:
-
-```json
-"registries": {
-  "@assistant-ui": "https://r.assistant-ui.com/{name}.json",
-  "@tool-ui": "https://tool-ui.com/r/{name}.json"
-}
-```
-
-2. Run the shadcn CLI with the `@tool-ui/<component>` namespace for the component you want. For example:
+1. Install from the registry:
 
 ```bash
-npx shadcn@latest add @tool-ui/plan
+npx shadcn@latest add @tool-ui/approval-card
 ```
 
+2. Define a backend tool that returns data matching the component's schema.
+3. Register a renderer in your toolkit that maps the tool name to the component.
 
-The CLI will copy `components/tool-ui/plan`, `components/tool-ui/shared` into your project and wire up the right Tailwind styles, just like any other shadcn block.
+Every Tool UI component ships with a colocated `schema.ts` that exports a Zod schema and a `safeParseSerializable{ComponentName}` function. Use these to validate tool output on both server and client.
 
-3. Repeat the command (or rerun the CLI) for additional Tool UI surfaces; the registry automatically lists every surface we ship, and each artifact brings along the `shared` helpers it needs.
+Browse all available components in the [Gallery](/docs/gallery).
 
-## Frontend tools (interactive Tool UIs)
+## Other runtimes
 
-Some Tool UIs (especially decision surfaces like **Option List**) are easiest to model as **frontend tools**: the model calls a tool with Tool UI props as the arguments, and your UI calls `addResult(...)` after the user confirms.
+[assistant-ui](https://www.assistant-ui.com/) supports multiple runtimes beyond AI SDK: [LangGraph](https://langchain-ai.github.io/langgraphjs/), LangServe, [Mastra](https://mastra.dev/), or custom backends. The examples above use AI SDK v6.
 
-If you're using `AssistantChatTransport`, it forwards **system instructions** and **registered tools** in the request body. Make sure your `/api/chat` route reads and forwards them, otherwise the model won't see your frontend tools.
+Tool UI components also work without assistant-ui — you'd parse tool outputs and render components manually. For the best experience, we recommend assistant-ui.
 
-```ts
-import { openai } from "@ai-sdk/openai";
-import {
-  streamText,
-  convertToModelMessages,
-  jsonSchema,
-  type UIMessage,
-  type JSONSchema7,
-} from "ai";
+## Next steps
 
-type ForwardedTools = Record<
-  string,
-  { description?: string; parameters: JSONSchema7 }
->;
-
-function toStreamTextTools(tools?: ForwardedTools) {
-  if (!tools) return undefined;
-  return Object.fromEntries(
-    Object.entries(tools).map(([name, tool]) => [
-      name,
-      {
-        ...(tool.description ? { description: tool.description } : {}),
-        inputSchema: jsonSchema(tool.parameters),
-      },
-    ]),
-  );
-}
-
-export async function POST(req: Request) {
-  const body = (await req.json()) as {
-    messages: UIMessage[];
-    system?: string;
-    tools?: ForwardedTools;
-  };
-
-  const result = streamText({
-    model: openai("gpt-4o"),
-    messages: await convertToModelMessages(body.messages),
-    system: body.system,
-    tools: toStreamTextTools(body.tools),
-  });
-
-  return result.toUIMessageStreamResponse();
-}
-```
-
-### Register a frontend tool (assistant-ui)
-
-When the tool is frontend/interactive, you register the tool **on the client** (so it gets forwarded by `AssistantChatTransport`) and render a Tool UI when it is called.
-
-```tsx
-"use client";
-
-import { type Toolkit } from "@assistant-ui/react";
-import { OptionList } from "@/components/tool-ui/option-list";
-import {
-  safeParseSerializableOptionList,
-  SerializableOptionListSchema,
-} from "@/components/tool-ui/option-list/schema";
-import { createArgsToolRenderer } from "@/components/tool-ui/shared";
-
-export const toolkit: Toolkit = {
-  selectFormat: {
-    description: "Ask the user to choose an output format.",
-    parameters: SerializableOptionListSchema,
-    render: createArgsToolRenderer({
-      safeParse: safeParseSerializableOptionList,
-      idPrefix: "format-selection",
-      render: (parsedArgs, { result, addResult }) => {
-        if (result) {
-          return (
-            <OptionList {...parsedArgs} value={undefined} choice={result} />
-          );
-        }
-
-        return (
-          <OptionList
-            {...parsedArgs}
-            // Avoid controlled selection in LLM-driven payloads.
-            value={undefined}
-            onConfirm={(selection) => addResult?.(selection)}
-          />
-        );
-      },
-    }),
-  },
-};
-```
-
-Register this toolkit with `Tools({ toolkit })` under `<AssistantRuntimeProvider>` so the tool and UI are forwarded by `AssistantChatTransport`.
-
-### Auto-continue after `addResult(...)` (AI SDK runtime)
-
-If you want the assistant to continue automatically after the user confirms (instead of waiting for the next user message), enable AI SDK's auto-resubmit behavior:
-
-```tsx
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
-import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
-
-const runtime = useChatRuntime({
-  transport: new AssistantChatTransport({ api: "/api/chat" }),
-  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-});
-```
-
-## Other Frameworks
-
-Tool UI components work with any React app. Without assistant-ui, you'll need to manually parse tool outputs and render components. For the best experience, we recommend using assistant-ui.
-
-Tool UI components are installed from registry entries, and each entry includes `components/tool-ui/shared` automatically.
-
-## Runtime Options
-
-[assistant-ui](https://www.assistant-ui.com/) supports multiple runtimes: [AI SDK](https://ai-sdk.dev/), [LangGraph](https://langchain-ai.github.io/langgraphjs/), LangServe, [Mastra](https://mastra.dev/), or custom backends. The examples above use AI SDK v6.
-
-## Next Steps
-
-- [**Explore Components**](/docs/data-table): Data Table, Image, Video, Link Preview, Option List, X Post, Instagram Post, LinkedIn Post
-- [**UI Guidelines**](/docs/design-guidelines): Learn the interaction patterns
-- [**Examples**](https://github.com/assistant-ui/assistant-ui/tree/main/examples): Full implementations
+- [**Actions**](/docs/actions): Learn how Tool UIs handle user interaction — clicks, selections, and decisions that feed back into the conversation.
+- [**UI Guidelines**](/docs/design-guidelines): Design principles for building effective conversation-native UIs.
+- [**Advanced**](/docs/advanced): Typed tools with `InferUITools`, frontend tools for interactive UIs, and auto-continue patterns.
+- [**Gallery**](/docs/gallery): Browse all components with live previews.

--- a/app/docs/receipts/content.mdx
+++ b/app/docs/receipts/content.mdx
@@ -9,6 +9,8 @@ import { ApprovalCard } from "@/components/tool-ui/approval-card";
   mdxPath="app/docs/receipts/content.mdx"
 />
 
+When a user makes a consequential decision in chat — approving a deploy, selecting a plan, confirming a purchase — the interactive UI needs to become a permanent record of what happened. Without this transition, scrolling back through the conversation shows a clickable button for a decision that was already made. Receipts solve this by replacing the interactive state with a confirmation of the choice.
+
 When a user takes an action with consequences, the tool UI should transition to a **receipt state** that confirms what happened. This gives the user proof of their decision and something the assistant can reference later.
 
 ## Why Receipts Matter


### PR DESCRIPTION
## Summary

- **Overview**: Replaced abstract principles with a concrete side-by-side comparison (raw JSON vs rendered Tool UI components) and live embedded demos
- **Quick Start**: Restructured as a hands-on walkthrough — install assistant-ui, add a LinkPreview component, wire it to a backend tool, and render it
- **Advanced**: Added new "Frontend tools" section explaining how to register interactive decision surfaces (e.g. OptionList) as client-side tools with `addResult(...)` flow
- **Receipts**: Added introductory paragraph explaining the problem receipts solve

## Test plan

- [ ] Verify all four doc pages render without errors on the Vercel preview
- [ ] Confirm code blocks have correct syntax highlighting
- [ ] Check that the side-by-side MockThread comparison in Overview renders correctly
- [ ] Verify internal links between doc pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)