### PR TITLE
fix: add default spacing between ToolUI.Surface and actions

### DIFF
--- a/components/tool-ui/shared/tool-ui.tsx
+++ b/components/tool-ui/shared/tool-ui.tsx
@@ -9,9 +9,10 @@ import { DecisionActions } from "./decision-actions";
 export interface ToolUIProps {
   id: string;
   children: ReactNode;
+  className?: string;
 }
 
-function ToolUIRoot({ id, children }: ToolUIProps) {
+function ToolUIRoot({ id, children, className }: ToolUIProps) {
   const [surfaceMounted, setSurfaceMounted] = useState(false);
 
   const value = useMemo(
@@ -20,7 +21,15 @@ function ToolUIRoot({ id, children }: ToolUIProps) {
   );
 
   return (
-    <ToolUIContext.Provider value={value}>{children}</ToolUIContext.Provider>
+    <ToolUIContext.Provider value={value}>
+      <div
+        className={cn("flex flex-col gap-3", className)}
+        data-slot="tool-ui"
+        data-tool-ui-id={id}
+      >
+        {children}
+      </div>
+    </ToolUIContext.Provider>
   );
 }
 

--- a/lib/tests/tool-ui/shared/tool-ui-compound-hydration-contract.test.ts
+++ b/lib/tests/tool-ui/shared/tool-ui-compound-hydration-contract.test.ts
@@ -47,6 +47,35 @@ async function cleanupHydration(root: Root, container: HTMLDivElement) {
 }
 
 describe("tool-ui compound hydration contracts", () => {
+  it("applies a default stacked gap layout at the ToolUI root", async () => {
+    const app = h(
+      ToolUIRoot,
+      { id: "hydrate-root-layout" },
+      h(ToolUI.Surface, null, h("div", { "data-slot": "surface" }, "Surface")),
+      h(
+        ToolUI.Actions,
+        null,
+        h(ToolUI.LocalActions, {
+          actions: localActions,
+          onAction: async () => undefined,
+        }),
+      ),
+    );
+
+    const serverHtml = renderToString(app);
+    const container = createHydrationContainer(serverHtml);
+    const root = await hydrate(container, app);
+
+    const toolUIRoot = container.querySelector('[data-slot="tool-ui"]');
+    expect(toolUIRoot).not.toBeNull();
+    expect(toolUIRoot?.getAttribute("data-tool-ui-id")).toBe("hydrate-root-layout");
+    expect(toolUIRoot?.className).toContain("flex");
+    expect(toolUIRoot?.className).toContain("flex-col");
+    expect(toolUIRoot?.className).toContain("gap-3");
+
+    await cleanupHydration(root, container);
+  });
+
   it("reveals ToolUI.Actions only after hydration mounts ToolUI.Surface", async () => {
     const app = h(
       ToolUIRoot,


### PR DESCRIPTION
## Summary
- make `ToolUI` render a default stacked root wrapper (`flex flex-col gap-3`) so `ToolUI.Surface` and `ToolUI.Actions` always have spacing
- add optional `className` to `ToolUI` for callers that need custom root layout spacing
- add a hydration contract test asserting the default root layout exists and includes spacing classes

## Validation
- `pnpm test lib/tests/tool-ui/shared/tool-ui-compound-hydration-contract.test.ts`
- `pnpm test lib/tests/tool-ui/shared/tool-ui-compound-contract.test.ts`
- `pnpm test lib/tests/tool-ui/docs/docs-runtime-end-to-end-contract.test.ts`
