### PR TITLE
Weather widget: rewrite docs to embrace the absurdity

### DIFF
--- a/app/docs/weather-widget/content.mdx
+++ b/app/docs/weather-widget/content.mdx
@@ -3,11 +3,11 @@ import { WeatherWidget } from "@/components/tool-ui/weather-widget/runtime";
 
 <DocsHeader
   title="Weather Widget"
-  description="Display weather conditions and forecasts."
+  description="The most overbuilt weather widget you'll ever see. On purpose."
   mdxPath="app/docs/weather-widget/content.mdx"
 />
 
-"72°F and partly cloudy" is accurate but forgettable. A visual forecast with icons, highs and lows, and a time-of-day background tells the same story in a way the user actually remembers. WeatherWidget renders current conditions and a multi-day forecast from any weather API, complete with 13 condition codes and time-aware scene styling.
+Weather widgets have become the "hello world" of generative UI—Vercel shows one in their docs, every AI demo seems to start with one. So we built the most absurdly detailed weather widget anyone has ever made. Real-time WebGL atmospheric effects, physically-based weather simulations, time-of-day scene rendering, 13 condition codes. It's genuinely more detailed than Apple's iOS weather app. Starting to think there's something poetic about taking the most clich&eacute;d demo component in AI and overengineering it until it transcends the bit.
 
 **Role:** Information. Displays data without requiring user input. See [Design Guidelines](/docs/design-guidelines) for how component roles work.
 

--- a/lib/docs/component-registry.ts
+++ b/lib/docs/component-registry.ts
@@ -200,7 +200,7 @@ export const componentsRegistry: ComponentMeta[] = [
   {
     id: "weather-widget",
     label: "Weather Widget",
-    description: "Display weather conditions and forecasts",
+    description: "Probably more weather widget than anyone asked for",
     path: "/docs/weather-widget",
     category: "display",
   },

--- a/lib/presets/weather-widget.ts
+++ b/lib/presets/weather-widget.ts
@@ -41,7 +41,7 @@ export const weatherWidgetPresets: Record<
   PresetWithCodeGen<WeatherWidgetPayload>
 > = {
   thunderstorm: {
-    description: "Dramatic thunderstorm with lightning",
+    description: "Kansas City having a night",
     data: {
       version: "3.1",
       id: "weather-widget-thunderstorm",
@@ -66,7 +66,7 @@ export const weatherWidgetPresets: Record<
     generateExampleCode: generateWeatherWidgetCode,
   },
   "cold-snap": {
-    description: "Winter weather with snow at night",
+    description: "Minneapolis doing Minneapolis things",
     data: {
       version: "3.1",
       id: "weather-widget-cold-snap",
@@ -91,7 +91,7 @@ export const weatherWidgetPresets: Record<
     generateExampleCode: generateWeatherWidgetCode,
   },
   "rainy-week": {
-    description: "Persistent rain throughout the week",
+    description: "Seattle, so... rain",
     data: {
       version: "3.1",
       id: "weather-widget-rainy-week",
@@ -116,7 +116,7 @@ export const weatherWidgetPresets: Record<
     generateExampleCode: generateWeatherWidgetCode,
   },
   "cloudy-sunset": {
-    description: "Dramatic overcast sunset",
+    description: "That golden hour cloud thing",
     data: {
       version: "3.1",
       id: "weather-widget-cloudy-sunset",
@@ -141,7 +141,7 @@ export const weatherWidgetPresets: Record<
     generateExampleCode: generateWeatherWidgetCode,
   },
   "sunny-forecast": {
-    description: "Clear skies and warm temperatures",
+    description: "San Diego being San Diego",
     data: {
       version: "3.1",
       id: "weather-widget-sunny-forecast",


### PR DESCRIPTION
## Summary

- Rewrites weather widget intro copy to acknowledge the "hello world of tool UIs" trope and show off the WebGL effects, Apple Weather comparison, and general overengineering
- Updates component registry description: *"Probably more weather widget than anyone asked for"*
- Gives preset descriptions personality tied to their cities (e.g. "Seattle, so... rain", "San Diego being San Diego")

Tone is tongue-in-cheek and self-referential — we know it's ridiculous and that's exactly the point.

## Files changed

- `app/docs/weather-widget/content.mdx` — DocsHeader description + overview paragraph
- `lib/docs/component-registry.ts` — one-liner description
- `lib/presets/weather-widget.ts` — 5 preset description strings

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint:fix` passes
- [ ] Doc page renders at `/docs/weather-widget`
- [ ] Preset selector shows updated descriptions
- [ ] Copy reads naturally and lands the self-referential tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)