### PR TITLE
Refine Overview docs page mock chat visuals

### DIFF
--- a/app/docs/_components/interactive-option-demo.tsx
+++ b/app/docs/_components/interactive-option-demo.tsx
@@ -50,7 +50,7 @@ export function InteractiveOptionDemo() {
   }, []);
 
   return (
-    <div className="relative">
+    <div>
       <MockThread caption="Click an option and confirm — then reset to try again">
         <MockMessage role="user">
           Help me pick a database for the new project
@@ -80,7 +80,7 @@ export function InteractiveOptionDemo() {
       {choice && (
         <div
           className={cn(
-            "absolute -bottom-4 left-1/2 -translate-x-1/2",
+            "flex justify-center",
             "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200",
           )}
         >

--- a/app/docs/_components/mock-thread.tsx
+++ b/app/docs/_components/mock-thread.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import { cn } from "@/lib/ui/cn";
-import { ArrowUp } from "lucide-react";
 
 interface MockMessageProps {
   role: "user" | "assistant";
@@ -13,7 +12,7 @@ export function MockMessage({ role, children }: MockMessageProps) {
   if (role === "user") {
     return (
       <div className="flex justify-end" data-role="user">
-        <div className="bg-primary text-primary-foreground rounded-full px-4 py-2">
+        <div className="rounded-full bg-[#007AFF] px-4 py-2 text-white dark:bg-[#002b90]">
           {children}
         </div>
       </div>
@@ -35,34 +34,17 @@ interface MockThreadProps {
 
 export function MockThread({ children, className, caption }: MockThreadProps) {
   return (
-    <figure className={cn("not-prose my-8", className)}>
-      <div className="border-border bg-background overflow-hidden rounded-xl border shadow-sm">
+    <figure className={cn("not-prose my-8 flex flex-col", className)}>
+      <div className="border-border bg-background flex flex-1 flex-col overflow-hidden rounded-xl border shadow-sm">
         {/* Title bar */}
-        <div className="bg-muted/50 border-border flex items-center gap-2 border-b px-4 py-2.5">
-          <div className="flex gap-1.5">
-            <span className="bg-border size-2.5 rounded-full" />
-            <span className="bg-border size-2.5 rounded-full" />
-            <span className="bg-border size-2.5 rounded-full" />
-          </div>
-          <span className="text-muted-foreground flex-1 text-center text-xs font-medium">
+        <div className="bg-muted/50 border-border border-b px-4 py-2.5 text-center">
+          <span className="text-muted-foreground text-xs font-medium">
             Chat
           </span>
-          <div className="w-[52px]" /> {/* Spacer to balance the dots */}
         </div>
         {/* Messages */}
         <div className="flex flex-col gap-4 p-4 [&>[data-role=user]+[data-role=assistant]]:mt-2 [&>[data-role=assistant]+[data-role=user]]:mt-2">
           {children}
-        </div>
-        {/* Composer */}
-        <div className="border-border border-t px-4 py-3">
-          <div className="bg-muted/50 border-border flex items-center gap-2 rounded-full border px-4 py-2">
-            <span className="text-muted-foreground/60 flex-1 text-sm">
-              Message...
-            </span>
-            <div className="bg-muted text-muted-foreground/60 flex size-7 items-center justify-center rounded-full">
-              <ArrowUp className="size-4" />
-            </div>
-          </div>
         </div>
       </div>
       {caption && (


### PR DESCRIPTION
## Summary
- **Blue user bubbles**: Changed from theme-based `bg-primary` to explicit `bg-[#007AFF]` (light) / `dark:bg-[#002b90]` (dark), matching the landing page showcase
- **Removed composer bar**: The "Message..." input section at the bottom of mock threads was removed, along with the unused `ArrowUp` import
- **Removed traffic light dots**: The three dots and their balancing spacer were removed; title bar simplified to just centered "Chat" label
- **Equal height mock threads**: `MockThread` figure uses `flex flex-col` and inner card uses `flex flex-1 flex-col` so they stretch in grid layouts
- **Fixed "Try again" button overlap**: `InteractiveOptionDemo` button now renders in normal document flow with `flex justify-center` instead of absolute positioning

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint:fix` passes (pre-existing warnings in unrelated files only)
- [ ] Visually confirm at `/docs/overview`: blue user bubbles, no composer bars, no traffic light dots, equal-height panels
- [ ] Interactive option demo: select → confirm → "Try again" button appears below caption without overlap
- [ ] `/docs/actions` page (other MockThread consumer) renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)