### PR TITLE
fix(docs): simplify code diff header preview

### DIFF
--- a/lib/docs/preview-config.tsx
+++ b/lib/docs/preview-config.tsx
@@ -455,7 +455,7 @@ export const previewConfigs: Record<
     presets: codeDiffPresets as Record<string, PresetWithCodeGen<unknown>>,
     defaultPreset: "refactor" satisfies CodeDiffPresetName,
     chatContext: {
-      userMessage: "Can you refactor checkAuth to return a result instead of throwing?",
+      userMessage: "Can you make fetchUser return null instead of throwing?",
       preamble: "Here's the updated function:",
     },
     renderComponent: ({ data }) => {

--- a/lib/presets/code-diff.ts
+++ b/lib/presets/code-diff.ts
@@ -61,23 +61,25 @@ export const codeDiffPresets: Record<
   PresetWithCodeGen<SerializableCodeDiff>
 > = {
   refactor: {
-    description: "Function rename and return type change",
+    description: "Safer error handling in fetch helper",
     data: {
       id: "code-diff-preview-refactor",
       language: "typescript",
       filename: "lib/auth.ts",
       lineNumbers: "visible",
       diffStyle: "unified",
-      oldCode: `export function checkAuth(token: string) {
-  const decoded = jwt.verify(token, SECRET);
-  if (!decoded) throw new Error("Invalid token");
-  return db.users.find(u => u.id === decoded.sub);
-}`,
-      newCode: `export function verifySession(token: string): AuthResult {
-  const decoded = jwt.verify(token, SECRET);
-  if (!decoded) return { ok: false, error: "invalid_token" };
-  return { ok: true, user: db.users.findById(decoded.sub) };
-}`,
+      oldCode: `export async function fetchUser(id: string) {
+  const res = await db.users.findUnique({ where: { id } });
+  if (!res) throw new Error("User not found");
+  return res;
+}
+`,
+      newCode: `export async function fetchUser(id: string) {
+  const res = await db.users.findUnique({ where: { id } });
+  if (!res) return null;
+  return res;
+}
+`,
     } satisfies SerializableCodeDiff,
     generateExampleCode: generateCodeDiffCode,
   },


### PR DESCRIPTION
## Summary
- Replaced the noisy "refactor" preset where every line changed with a calmer `fetchUser` diff
- Only 1 of 5 lines changes (`throw new Error` → `return null`), giving the eye stable context lines to anchor on
- Trailing newlines eliminate the "No newline at end of file" clutter

## Before / After

**Before:** Every line red or green — dense, overwhelming first impression
**After:** 4 stable context lines, 1 meaningful change — clean and approachable

## Test plan
- [ ] Visit `/docs/code-diff` and confirm the header preview shows a calm diff with mostly unchanged lines
- [ ] Confirm no "No newline at end of file" message appears
- [ ] Click the "Code" tab to verify the generated example code looks correct
- [ ] Check other presets (bug-fix, patch, split, collapsed, minimal) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)