### PR TITLE
docs: refine overview page header styling and description copy

### DIFF
--- a/app/docs/_components/mock-thread.tsx
+++ b/app/docs/_components/mock-thread.tsx
@@ -37,7 +37,7 @@ export function MockThread({ children, className, caption }: MockThreadProps) {
     <figure className={cn("not-prose my-8 flex flex-col", className)}>
       <div className="border-border bg-background flex flex-1 flex-col overflow-hidden rounded-xl border shadow-sm">
         {/* Title bar */}
-        <div className="bg-muted/50 border-border border-b px-4 py-2.5 text-center">
+        <div className="bg-muted/50 border-border border-b px-4 py-1 text-center">
           <span className="text-muted-foreground text-xs font-medium">
             Chat
           </span>

--- a/app/docs/overview/content.mdx
+++ b/app/docs/overview/content.mdx
@@ -50,7 +50,7 @@ Tool UI is a component library for this problem. Each component turns a specific
   </MockThread>
 </div>
 
-Same data, different experience. The left side dumps JSON the user has to read. The right side renders a clickable card that looks and behaves like a native part of the conversation.
+Same data, different experience. The left side either dumps JSON to the user or, if you're using a markdown renderer like MDX, gives you a plain text link. The right side renders a clickable card that looks and behaves like a native part of the conversation.
 
 ## What is tool calling?
 


### PR DESCRIPTION
## Summary
- Slim down the mock chat header bar padding (`py-2.5` → `py-1`) for a tighter visual
- Update the first example description to mention both JSON dumps and markdown/MDX plain text links as alternatives

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Visual check: overview page shows thinner mock chat header bars
- [ ] Visual check: updated description text reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)