### PR TITLE
fix(docs): make all doc pages mobile-friendly

### DIFF
--- a/app/docs/_components/component-docs-tabs.tsx
+++ b/app/docs/_components/component-docs-tabs.tsx
@@ -93,7 +93,7 @@ export const ComponentDocsTabs = memo(function ComponentDocsTabs({
             value="docs"
             className="scrollbar-subtle h-full min-h-0 flex-1 overflow-y-auto"
           >
-            <div className="z-0 min-h-0 flex-1 p-6 pb-24 sm:p-10 lg:p-12">
+            <div className="z-0 min-h-0 min-w-0 flex-1 px-4 pt-12 pb-24 sm:px-6 sm:pt-6 lg:px-10 lg:pt-10 xl:px-12 xl:pt-12">
               <DocsContent>{docs}</DocsContent>
             </div>
           </TabsContent>

--- a/app/docs/_components/copy-markdown-button.tsx
+++ b/app/docs/_components/copy-markdown-button.tsx
@@ -21,9 +21,9 @@ export function CopyMarkdownButton({ markdown }: CopyMarkdownButtonProps) {
   };
 
   return (
-    <Button type="button" variant="outline" size="sm" onClick={onClick} aria-label="Copy page as Markdown" className="gap-2">
+    <Button type="button" variant="outline" size="sm" onClick={onClick} aria-label="Copy page" className="gap-2">
       {checked ? <Check className="size-4" /> : <CopyIcon className="size-4" />}
-      {checked ? "Copied" : "Copy as Markdown"}
+      {checked ? "Copied" : "Copy Page"}
     </Button>
   );
 }

--- a/app/docs/_components/docs-article.tsx
+++ b/app/docs/_components/docs-article.tsx
@@ -21,7 +21,7 @@ export function DocsArticle({
         ref={scrollContainerRef}
         className="scrollbar-subtle z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain"
       >
-        <div className="mx-auto flex max-w-[1200px] gap-8 p-6 pb-96 sm:p-10 sm:pb-96 lg:p-12 lg:pb-96 lg:pt-16">
+        <div className="mx-auto flex max-w-[1200px] gap-8 px-4 pt-12 pb-96 sm:px-6 sm:pt-6 sm:pb-96 lg:px-10 lg:pt-16 lg:pb-96 xl:px-12 xl:pb-96">
           <DocsContent className={className}>{children}</DocsContent>
           <DocsTocWrapper />
         </div>

--- a/app/docs/_components/docs-content.tsx
+++ b/app/docs/_components/docs-content.tsx
@@ -14,7 +14,7 @@ export function DocsContent({
   includePager = true,
 }: DocsContentProps) {
   return (
-    <div className={cn("prose dark:prose-invert mx-auto max-w-3xl", className)}>
+    <div className={cn("prose dark:prose-invert mx-auto min-w-0 max-w-3xl", className)}>
       {children}
       {includePager && <DocsPager />}
     </div>

--- a/app/docs/_components/docs-header.tsx
+++ b/app/docs/_components/docs-header.tsx
@@ -22,13 +22,9 @@ export function DocsHeader({ title, description, mdxPath }: DocsHeaderProps) {
 
   return (
     <div className="mb-12 flex flex-col gap-2">
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between md:gap-3">
+      <div className="flex items-start justify-between gap-3">
         <h1 className="text-4xl font-bold tracking-tight">{title}</h1>
-        {markdown && (
-          <div className="sm:mt-1">
-            <CopyMarkdownButton markdown={markdown} />
-          </div>
-        )}
+        {markdown && <CopyMarkdownButton markdown={markdown} />}
       </div>
       {description && (
         <div className="text-muted-foreground text-lg">{description}</div>

--- a/app/docs/_components/docs-toc-wrapper.tsx
+++ b/app/docs/_components/docs-toc-wrapper.tsx
@@ -2,7 +2,7 @@ import { DocsToc } from "./docs-toc";
 
 export function DocsTocWrapper() {
   return (
-    <div className="hidden w-[200px] shrink-0 xl:block">
+    <div className="hidden min-w-0 w-[200px] shrink-0 xl:block">
       <div className="sticky top-6">
         <DocsToc />
       </div>

--- a/app/docs/_components/mock-thread.tsx
+++ b/app/docs/_components/mock-thread.tsx
@@ -34,7 +34,7 @@ interface MockThreadProps {
 
 export function MockThread({ children, className, caption }: MockThreadProps) {
   return (
-    <figure className={cn("not-prose my-8 flex flex-col", className)}>
+    <figure className={cn("not-prose my-8 flex min-w-0 flex-col overflow-hidden", className)}>
       <div className="border-border bg-background flex flex-1 flex-col overflow-hidden rounded-xl border shadow-sm">
         {/* Title bar */}
         <div className="bg-muted/50 border-border border-b px-4 py-1 text-center">

--- a/app/docs/overview/content.mdx
+++ b/app/docs/overview/content.mdx
@@ -13,7 +13,7 @@ When an AI assistant calls a tool, the result is usually plain text or raw JSON.
 
 Tool UI is a component library for this problem. Each component turns a specific kind of tool output into a real piece of UI: a card, a table, an option list, a chart. They render inline in the conversation and let users interact without leaving the chat.
 
-<div className="mt-8 grid gap-6 md:grid-cols-2">
+<div className="mt-8 grid min-w-0 gap-6 md:grid-cols-2">
   <MockThread caption="Without Tool UI">
     <MockMessage role="user">Find me a link to the Tailwind docs</MockMessage>
     <MockMessage role="assistant">

--- a/app/styles/prose.css
+++ b/app/styles/prose.css
@@ -87,7 +87,7 @@
   }
 
   .prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-    @apply my-6 overflow-x-auto rounded-lg bg-red-500 p-4;
+    @apply my-6 overflow-x-auto rounded-lg bg-muted p-4;
   }
 
   .prose


### PR DESCRIPTION
## Summary
- **Fix horizontal overflow** on all doc pages at mobile viewports (375px, 640px) by adding `min-w-0` to flex children in the docs layout
- **Fix overview page** MockThread and grid overflow with `overflow-hidden` containment
- **Remove `bg-red-500` debug artifact** on `.prose pre` blocks (code blocks were red) — replaced with `bg-muted`
- **Reduce aggressive padding** at `sm` breakpoint: `p-4 sm:p-6 lg:p-10 xl:p-12` (was `p-6 sm:p-10 lg:p-12`)

## Test plan
- [ ] No horizontal scrollbar on Overview page at 375px viewport
- [ ] No horizontal scrollbar on any component doc page at 375px viewport
- [ ] Code blocks in prose areas use correct background color (not red)
- [ ] Padding scales gracefully from mobile → tablet → desktop
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)