### PR TITLE
fix(docs): remove duplicate install chrome from preview shell

### DIFF
--- a/apps/www/app/docs/_components/component-preview-shell.tsx
+++ b/apps/www/app/docs/_components/component-preview-shell.tsx
@@ -10,7 +10,6 @@ import { cn } from "@/lib/ui/cn";
 import { useResponsivePreview } from "@/hooks/use-responsive-preview";
 import { useTabSearchParam } from "@/hooks/use-tab-search-param";
 import { useCopyToClipboard } from "@/components/tool-ui/shared";
-import { InstallCommandBlock } from "./install-command-block";
 import { analytics } from "@/lib/analytics";
 
 const PREVIEW_MIN_WIDTH = 40;
@@ -200,11 +199,6 @@ export function ComponentPreviewShell({
 
       {/* Main content area */}
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-        {/* Install commands - above the gray preview, in main column only */}
-        <div className="shrink-0 border-b px-4 py-3 sm:px-6 lg:px-6">
-          <InstallCommandBlock componentId={componentId} variant="block" />
-        </div>
-
         {/* Mobile toolbar */}
         <div className="flex flex-col gap-3 border-b px-4 pt-3 pb-3 lg:hidden">
           <div className="scrollbar-subtle overflow-x-auto">{sidebar}</div>

--- a/apps/www/lib/tests/tool-ui/docs/component-preview-shell.test.tsx
+++ b/apps/www/lib/tests/tool-ui/docs/component-preview-shell.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { ComponentPreviewShell } from "@/app/docs/_components/component-preview-shell";
+
+describe("ComponentPreviewShell", () => {
+  test("does not render duplicate install command chrome above the preview area", () => {
+    render(
+      <ComponentPreviewShell
+        componentId="link-preview"
+        sidebar={<div>sidebar</div>}
+        preview={<div>preview</div>}
+        chatPanel={<div>chat</div>}
+        codePanel={<div>code</div>}
+        code={"const x = 1;"}
+      />,
+    );
+
+    expect(screen.queryByText("tool-agent")).toBeNull();
+    expect(screen.queryByText("shadcn")).toBeNull();
+    expect(screen.getByText("preview")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- fixes #152
- remove the duplicate install command block from `ComponentPreviewShell`
- keep install guidance in the docs header / sheet flow, which is the lighter touch requested in the issue
- add a focused regression test that the preview shell no longer renders duplicate `tool-agent` / `shadcn` chrome above the preview area

## Testing

- `pnpm --filter tool-ui-www lint:format`
- `pnpm --filter tool-ui-www test -- apps/www/lib/tests/tool-ui/docs/component-preview-shell.test.tsx apps/www/lib/tests/tool-ui/docs/gallery-layout.test.ts apps/www/lib/tests/tool-ui/docs/install-snippet-analytics.test.ts`
